### PR TITLE
Base Streaming Latency Calculation Exclusively on Correct Predictions

### DIFF
--- a/src/openbench/metric/streaming_latency_metrics/latency_metrics.py
+++ b/src/openbench/metric/streaming_latency_metrics/latency_metrics.py
@@ -89,7 +89,7 @@ class BaseStreamingLatency(BaseMetric):
             out = jiwer.process_words(normalizer(transcript_gt), normalizer(interim_results[l]))
             alignments_l = [out.alignments[0][i].type for i in range(len(out.alignments[0]))]
 
-            indices = [i for i, val in enumerate(alignments_l) if val == "equal" or val == "substitute"]
+            indices = [i for i, val in enumerate(alignments_l) if val == "equal"]
 
             if indices:
                 first_index = indices[0]


### PR DESCRIPTION
This PR updates the latency metric calculation logic. Previously, latency was computed based on the last correctly predicted or substituted word. With this change, latency is now calculated exclusively based on the last correctly predicted word.