### PR TITLE
Remove dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "torch==2.6.0",
     "scikit-learn==1.5.1",
     "speechbrain==1.0.2",
-    "python-dotenv>=1.0.0,<2",
     "websocket-client>=1.8.0,<2",
     "typer>=0.16.0",
     "pydub>=0.25.1,<0.26",

--- a/src/openbench/pipeline/streaming_transcription/deepgram.py
+++ b/src/openbench/pipeline/streaming_transcription/deepgram.py
@@ -8,7 +8,6 @@ import os
 import numpy as np
 import websockets
 from argmaxtools.utils import get_logger
-from dotenv import load_dotenv
 from pydantic import Field
 
 from openbench.dataset import StreamingSample
@@ -18,8 +17,6 @@ from ...pipeline_prediction import StreamingTranscript
 from ...types import PipelineType
 from .common import StreamingTranscriptionConfig, StreamingTranscriptionOutput
 
-
-load_dotenv()
 
 logger = get_logger(__name__)
 

--- a/src/openbench/pipeline/streaming_transcription/fireworks.py
+++ b/src/openbench/pipeline/streaming_transcription/fireworks.py
@@ -11,7 +11,6 @@ import torch
 import torchaudio
 import websocket
 from argmaxtools.utils import get_logger
-from dotenv import load_dotenv
 
 from openbench.dataset import StreamingSample
 
@@ -20,8 +19,6 @@ from ...pipeline_prediction import StreamingTranscript
 from ...types import PipelineType
 from .common import StreamingTranscriptionConfig, StreamingTranscriptionOutput
 
-
-load_dotenv()
 
 logger = get_logger(__name__)
 

--- a/src/openbench/pipeline/streaming_transcription/gladia.py
+++ b/src/openbench/pipeline/streaming_transcription/gladia.py
@@ -10,7 +10,6 @@ from typing import Literal, TypedDict
 import numpy as np
 import requests
 from argmaxtools.utils import get_logger
-from dotenv import load_dotenv
 from websockets.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosedOK
 
@@ -21,8 +20,6 @@ from ...pipeline_prediction import StreamingTranscript
 from ...types import PipelineType
 from .common import StreamingTranscriptionConfig, StreamingTranscriptionOutput
 
-
-load_dotenv()
 
 logger = get_logger(__name__)
 

--- a/src/openbench/pipeline/streaming_transcription/openai.py
+++ b/src/openbench/pipeline/streaming_transcription/openai.py
@@ -12,7 +12,6 @@ import torch
 import torchaudio
 import websockets
 from argmaxtools.utils import get_logger
-from dotenv import load_dotenv
 
 from openbench.dataset import StreamingSample
 
@@ -21,8 +20,6 @@ from ...pipeline_prediction import StreamingTranscript
 from ...types import PipelineType
 from .common import StreamingTranscriptionConfig, StreamingTranscriptionOutput
 
-
-load_dotenv()
 
 logger = get_logger(__name__)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2216,7 +2216,6 @@ dependencies = [
     { name = "pyannote-audio" },
     { name = "pydantic" },
     { name = "pydub" },
-    { name = "python-dotenv" },
     { name = "rich" },
     { name = "scikit-learn" },
     { name = "speechbrain" },
@@ -2262,7 +2261,6 @@ requires-dist = [
     { name = "pyannote-audio", specifier = ">=3.3.2,<4" },
     { name = "pydantic", specifier = ">=2.9.2,<3" },
     { name = "pydub", specifier = ">=0.25.1,<0.26" },
-    { name = "python-dotenv", specifier = ">=1.0.0,<2" },
     { name = "rich", specifier = ">=13.0.0,<14" },
     { name = "scikit-learn", specifier = "==1.5.1" },
     { name = "speechbrain", specifier = "==1.0.2" },
@@ -2960,15 +2958,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

- Removes `python-dotenv` dependency, the library shouldn't have the responsibility to set env variables
- Removed `load_dotenv` calls from streaming transcription APIs