### PR TITLE
Add audio name to sample results and logged predictions

### DIFF
--- a/src/openbench/runner/benchmark.py
+++ b/src/openbench/runner/benchmark.py
@@ -99,6 +99,7 @@ class BenchmarkRunner:
         sample_results_attributes = dict(
             dataset_name=dataset_name,
             sample_id=sample_id,
+            audio_name=sample.audio_name,
             pipeline_name=pipeline.__class__.__name__,
             audio_duration=audio_duration,
             **output.model_dump(),

--- a/src/openbench/runner/data_models.py
+++ b/src/openbench/runner/data_models.py
@@ -18,6 +18,7 @@ class BaseSampleResult(BaseModel, Generic[Prediction]):
 
     dataset_name: str = Field(..., description="The name of the dataset")
     sample_id: int = Field(..., description="The id of the sample")
+    audio_name: str = Field(..., description="The name of the audio file")
     pipeline_name: str = Field(..., description="The name of the pipeline")
     prediction: Prediction = Field(..., description="The predicted diarization result")
     prediction_time: float = Field(

--- a/src/openbench/runner/wandb_logger.py
+++ b/src/openbench/runner/wandb_logger.py
@@ -114,8 +114,7 @@ class WandbLogger(ABC, Generic[SampleResult]):
 
         for sample_result in sample_results:
             prediction = sample_result.prediction
-            sample_id = sample_result.sample_id
-            filename = f"_sample_{sample_id}.rttm"
+            filename = sample_result.audio_name
             prediction.to_annotation_file(save_dir, filename)
 
         artifact = wandb.Artifact(


### PR DESCRIPTION
# What does this PR do?

- Adds audio file name to sample results
- When saving predictions, it uses the audio file name as the prediction file name