### PR TITLE
Fix openbench-cli evaluate when using configs

### DIFF
--- a/src/openbench/cli/commands/evaluate.py
+++ b/src/openbench/cli/commands/evaluate.py
@@ -326,6 +326,10 @@ def evaluate(
     # Store original working directory
     original_cwd = os.getcwd()
 
+    # Get absolute path for evaluation config before changing working directory
+    if evaluation_config_path is not None:
+        evaluation_config_path = evaluation_config_path.absolute()
+
     try:
         # Set output_dir as working dir
         os.chdir(output_dir)


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug that was previously preventing the usage of `--evaluation-config` if the path wasn't provided as an absolute path. We first convert the path to absolute before changing the working directory for logging purposes