### PR TITLE
fix: callhome dataset alias

### DIFF
--- a/src/openbench/dataset/dataset_aliases.py
+++ b/src/openbench/dataset/dataset_aliases.py
@@ -124,9 +124,7 @@ def register_dataset_aliases() -> None:
 
     DatasetRegistry.register_alias(
         "callhome",
-        DatasetConfig(
-            dataset_id=os.getenv("CALLHOME_DATASET_REPO_ID", "argmaxinc/callhome"), split="part2", num_samples=5
-        ),
+        DatasetConfig(dataset_id=os.getenv("CALLHOME_DATASET_REPO_ID", "argmaxinc/callhome"), split="part2"),
         supported_pipeline_types={
             PipelineType.DIARIZATION,
         },


### PR DESCRIPTION
# What does this PR do?

Fix callhome aliasa `num_samples` that was left in there for testing purposes