### PR TITLE
FIx base dataset audio_name when no path is provided by the dataset

### DIFF
--- a/src/openbench/dataset/dataset_base.py
+++ b/src/openbench/dataset/dataset_base.py
@@ -101,6 +101,7 @@ class BaseDataset(ABC, Generic[SampleType]):
     def __getitem__(self, idx: int) -> SampleType:
         """Get a sample by index - concrete implementation using prepare_sample."""
         row = self.ds[idx]
+        row["idx"] = idx
         audio_name, waveform, sample_rate = self._extract_audio_info(row)
         reference, extra_info = self.prepare_sample(row)
 
@@ -142,7 +143,7 @@ class BaseDataset(ABC, Generic[SampleType]):
     def _extract_audio_info(self, row: dict) -> tuple[str, np.ndarray, int]:
         """Extract common audio information from dataset row."""
         audio = row["audio"]
-        audio_name = f"sample_{row.get('idx', 0)}"
+        audio_name = f"sample_{row['idx']}"
         if "path" in audio and audio["path"] is not None:
             audio_name = Path(audio["path"]).stem
         return audio_name, audio["array"], audio["sampling_rate"]


### PR DESCRIPTION
# What does this PR do?

This PR fixes how the `audio_name` is set in the `BaseDataset` class. Previously, we defaulted to `sample_0` for all samples if the audio column didn't provide a `path` (which is how we can get the original audio name used to create the HF dataset). 

This caused all the locally saved predictions to have the same name for `timit` datasets after we merged https://github.com/argmaxinc/OpenBench/pull/23, which is not the expected behavior. Now, we are getting the correct behavior.

### Before
All samples were overriding, causing only the left sample to be stored

<img width="340" height="44" alt="image" src="https://github.com/user-attachments/assets/38f80724-1718-41de-ae21-cb50fa3d3231" />


### After

All samples are correctly saved based on the name generated with the `BaseDataset` logic.

<img width="343" height="133" alt="image" src="https://github.com/user-attachments/assets/ae9c9af1-1e06-4383-8987-24b65f95daba" />

