### PR TITLE
Fix display table for None metrics

### DIFF
--- a/src/openbench/cli/commands/evaluate.py
+++ b/src/openbench/cli/commands/evaluate.py
@@ -261,6 +261,9 @@ def display_result(result: BenchmarkResult) -> None:
 
     global_results = result.global_results
     for global_result in global_results:
+        # For streaming pipelines we can have metrics that are not compatible and return N/A values
+        if global_result.global_result is None:
+            continue
         row = [
             global_result.dataset_name,
             global_result.pipeline_name,


### PR DESCRIPTION
# What does this PR do?

Fix the display table that pops up on `openbench-cli evaluate` completion. This was crashing for some streaming pipelines that are not compatible with a few streaming metrics, and we persisted these metrics' values as `None`, which was causing the error. New behavior: drop these metrics and display global results of the compatible metrics.

Here is a Before & After when running 

```bash
uv run openbench-cli evaluate \
    -p gladia-streaming \
    -d timit-debug \
    -m streaming_latency \
    -m wer \
    -m model_timestamp_streaming_latency
```

`uv run openbench-cli evaluate -p gladia-streaming -d timit-debug -m streaming_latency -m wer -m model_timestamp_streaming_latency`

### Before

<img width="2442" height="829" alt="image" src="https://github.com/user-attachments/assets/33204772-809c-40d3-84f8-bc134a54c773" />


### After

<img width="1324" height="790" alt="image" src="https://github.com/user-attachments/assets/b05be3f3-eecd-4958-9fd7-d85c361992d9" />


