### PR TITLE
Add Groq API as Transcription Pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pydub>=0.25.1,<0.26",
     "rich>=13.0.0,<14",
     "deepgram-sdk>=4.8.0",
+    "groq>=0.31.0",
 ]
 
 [project.scripts]

--- a/src/openbench/dataset/dataset_transcription.py
+++ b/src/openbench/dataset/dataset_transcription.py
@@ -1,16 +1,25 @@
 # For licensing see accompanying LICENSE.md file.
 # Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
 
-from typing import Any
+from typing_extensions import TypedDict
 
 from ..pipeline_prediction import Transcript
 from .dataset_base import BaseDataset, BaseSample
 
 
-class TranscriptionSample(BaseSample[Transcript, dict[str, Any]]):
+class TranscriptionExtraInfo(TypedDict, total=False):
+    """Extra info for transcription samples."""
+
+    language: str
+
+
+class TranscriptionSample(BaseSample[Transcript, TranscriptionExtraInfo]):
     """Transcription sample for pure transcription tasks."""
 
-    pass
+    @property
+    def language(self) -> str | None:
+        """Convenience property to access language from extra_info."""
+        return self.extra_info.get("language")
 
 
 class TranscriptionDataset(BaseDataset[TranscriptionSample]):
@@ -19,7 +28,7 @@ class TranscriptionDataset(BaseDataset[TranscriptionSample]):
     _expected_columns = ["audio", "transcript"]
     _sample_class = TranscriptionSample
 
-    def prepare_sample(self, row: dict) -> tuple[Transcript, dict[str, Any]]:
+    def prepare_sample(self, row: dict) -> tuple[Transcript, TranscriptionExtraInfo]:
         """Prepare transcript and extra info from dataset row."""
         transcript_words = row["transcript"]
         reference = Transcript.from_words_info(
@@ -28,5 +37,7 @@ class TranscriptionDataset(BaseDataset[TranscriptionSample]):
             end=row.get("word_timestamps_end"),
             speaker=None,  # No speakers for pure transcription
         )
-        extra_info: dict[str, Any] = {}
+        extra_info: TranscriptionExtraInfo = {}
+        if "language" in row:
+            extra_info["language"] = row["language"]
         return reference, extra_info

--- a/src/openbench/pipeline/pipeline_aliases.py
+++ b/src/openbench/pipeline/pipeline_aliases.py
@@ -26,6 +26,7 @@ from .streaming_transcription import (
     OpenAIStreamingPipeline,
 )
 from .transcription import (
+    GroqTranscriptionPipeline,
     SpeechAnalyzerPipeline,
     WhisperKitProTranscriptionPipeline,
     WhisperKitTranscriptionPipeline,
@@ -388,6 +389,29 @@ def register_pipeline_aliases() -> None:
         },
         description="WhisperKitPro transcription pipeline using the parakeet-v3 version of the model compressed to 494MB. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
+
+    PipelineRegistry.register_alias(
+        "groq-whisper-large-v3-turbo",
+        GroqTranscriptionPipeline,
+        default_config={
+            "model_id": "whisper-large-v3-turbo",
+            "temperature": 0.0,
+            "force_language": False,
+        },
+        description="Groq transcription pipeline using the whisper-large-v3-turbo model. Requires `GROQ_API_KEY` env var.",
+    )
+
+    PipelineRegistry.register_alias(
+        "groq-whisper-large-v3",
+        GroqTranscriptionPipeline,
+        default_config={
+            "model_id": "whisper-large-v3",
+            "temperature": 0.0,
+            "force_language": False,
+        },
+        description="Groq transcription pipeline using the whisper-large-v3 model. Requires `GROQ_API_KEY` env var.",
+    )
+
     ################# STREAMING TRANSCRIPTION PIPELINES #################
 
     PipelineRegistry.register_alias(

--- a/src/openbench/pipeline/transcription/__init__.py
+++ b/src/openbench/pipeline/transcription/__init__.py
@@ -3,6 +3,7 @@
 
 from .apple_speech_analyzer import SpeechAnalyzerConfig, SpeechAnalyzerPipeline
 from .common import TranscriptionOutput
+from .transcription_groq import GroqTranscriptionConfig, GroqTranscriptionPipeline
 from .transcription_whisperkitpro import WhisperKitProTranscriptionConfig, WhisperKitProTranscriptionPipeline
 from .whisperkit import WhisperKitTranscriptionConfig, WhisperKitTranscriptionPipeline
 

--- a/src/openbench/pipeline/transcription/transcription_groq.py
+++ b/src/openbench/pipeline/transcription/transcription_groq.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+
+import groq
+from argmaxtools.utils import get_logger
+from pydantic import Field
+
+from ...dataset import TranscriptionSample
+from ...pipeline_prediction import Transcript
+from ..base import Pipeline, PipelineType, register_pipeline
+from .common import TranscriptionConfig, TranscriptionOutput
+
+
+logger = get_logger(__name__)
+
+TEMP_AUDIO_DIR = Path("./temp_audio")
+
+
+class GroqEngine:
+    def __init__(self, model_id: str, temperature: float = 0.0, hint_language: bool = False) -> None:
+        if "GROQ_API_KEY" not in os.environ:
+            raise ValueError("`GROQ_API_KEY` is not set. Please set it in the environment variables.")
+
+        self.client = groq.Groq(api_key=os.environ["GROQ_API_KEY"])
+        self.model_id = model_id
+        self.temperature = temperature
+        self.hint_language = hint_language
+
+    def __call__(self, inputs: TranscriptionSample) -> str:
+        audio_file = inputs.save_audio(TEMP_AUDIO_DIR)
+        language = None
+        if self.hint_language and inputs.language is not None:
+            language = inputs.language
+
+        with open(audio_file, "rb") as f:
+            transcription = self.client.audio.transcriptions.create(
+                file=f,
+                model=self.model_id,
+                response_format="text",
+                language=language,
+                temperature=self.temperature,
+            )
+
+        return transcription
+
+
+class GroqTranscriptionConfig(TranscriptionConfig):
+    model_id: str = Field(
+        ...,
+        description="The ID of the Groq model to use",
+    )
+    temperature: float = Field(
+        default=0.0,
+        description="The temperature to use for the transcription",
+    )
+
+
+@register_pipeline
+class GroqTranscriptionPipeline(Pipeline):
+    _config_class = GroqTranscriptionConfig
+    pipeline_type = PipelineType.TRANSCRIPTION
+
+    def build_pipeline(self) -> GroqEngine:
+        return GroqEngine(
+            model_id=self.config.model_id,
+            temperature=self.config.temperature,
+            hint_language=self.config.force_language,
+        )
+
+    def parse_input(self, input_sample: TranscriptionSample) -> TranscriptionSample:
+        return input_sample
+
+    def parse_output(self, output: str) -> TranscriptionOutput:
+        return TranscriptionOutput(prediction=Transcript.from_words_info(words=output.split()))

--- a/uv.lock
+++ b/uv.lock
@@ -753,6 +753,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docker-pycreds"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,6 +1036,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
     { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055, upload-time = "2025-06-05T16:12:40.457Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817, upload-time = "2025-06-05T16:29:49.244Z" },
+]
+
+[[package]]
+name = "groq"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a2/77fd1460e7d55859219223719aa44ae8902a3a1ad333cd5faf330eb0b894/groq-0.31.0.tar.gz", hash = "sha256:182252e9bf0d696df607c137cbafa851d2c84aaf94bcfe9165c0bc231043490c", size = 136237, upload-time = "2025-08-05T23:14:01.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/f8/14672d69a91495f43462c5490067eeafc30346e81bda1a62848e897f9bc3/groq-0.31.0-py3-none-any.whl", hash = "sha256:5e3c7ec9728b7cccf913da982a9b5ebb46dc18a070b35e12a3d6a1e12d6b0f7f", size = 131365, upload-time = "2025-08-05T23:13:59.768Z" },
 ]
 
 [[package]]
@@ -2204,6 +2230,7 @@ dependencies = [
     { name = "boto3" },
     { name = "datasets" },
     { name = "deepgram-sdk" },
+    { name = "groq" },
     { name = "hdbscan" },
     { name = "hydra-core" },
     { name = "jiwer" },
@@ -2249,6 +2276,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.36.20,<2" },
     { name = "datasets", specifier = ">=3.1.0,<4" },
     { name = "deepgram-sdk", specifier = ">=4.8.0" },
+    { name = "groq", specifier = ">=0.31.0" },
     { name = "hdbscan", specifier = ">=0.8.40,<0.9" },
     { name = "hydra-core", specifier = ">=1.3.2,<2" },
     { name = "jiwer", specifier = ">=3.1.0,<4" },


### PR DESCRIPTION
# What does this PR do?

- Adds `Groq` as a transcription pipeline
- Adds `groq` Python SDK as a new dependency
- Adds new pipeline aliases `groq-whisper-large-v3-turbo` and `groq-whisper-large-v3`
- Defines `extra_info` for `TranscriptionSample`, which right now we expect to be a dict with `language` as key, enabling language hinting for transcription pipelines.

Now you can:

```bash
> export GROQ_API_KEY= <your-groq-api-key>
> uv run openbench-cli evaluate -p groq-whisper-large-v3-turbo -d librispeech-200 -m wer

📁 Output directory: outputs/2025-08-26/12-06-21
🔧 Running with alias mode
🔍 Validating configuration...
🔧 Creating pipeline: groq-whisper-large-v3-turbo
📊 Loading dataset: librispeech-200
🚀 Starting evaluation...
INFO:openbench.runner.utils:Creating directory .
INFO:openbench.runner.utils:Changing directory to .
INFO:openbench.runner.benchmark:Evaluating GroqTranscriptionPipeline on librispeech-200...
INFO:openbench.runner.benchmark:Executing in sequential mode
INFO:openbench.dataset.dataset_base:Saving audio to temp_audio/6930-75918-0013.wav
INFO:openbench.runner.benchmark:
=========================================================
Pipeline: GroqTranscriptionPipeline
Dataset: librispeech-200
Iteration: 1 of 200 (0.50%)
Prediction time: 0.3706 seconds
Audio duration: 2.94 seconds
Speed Factor: 7.933x
---------------------------------------------------------
Metrics:
MetricOptions.WER - Sample:    0
MetricOptions.WER - Global:    0
---------------------------------------------------------
=========================================================
```