### PR TITLE
Add plot method to DiarizationAnnotation

### DIFF
--- a/src/openbench/pipeline_prediction.py
+++ b/src/openbench/pipeline_prediction.py
@@ -5,11 +5,16 @@ import json
 import os
 from collections import defaultdict
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from pyannote.core import Annotation
+from argmaxtools.utils import get_logger
+from pyannote.core import Annotation, Segment
 from pyannote.database.util import load_rttm
 from pydantic import BaseModel, Field
+
+
+logger = get_logger(__name__)
 
 
 # Diarization Prediction
@@ -51,6 +56,102 @@ class DiarizationAnnotation(Annotation):
     @property
     def num_speakers(self) -> int:
         return len(np.unique(self.speakers))
+
+    def plot(self, ax: plt.Axes | None = None) -> plt.Axes:
+        """Plot diarization annotation as a timeline with speaker segments.
+
+        Args:
+            ax: Optional matplotlib axes to plot on. If None, creates new figure/axes.
+
+        Returns:
+            The matplotlib axes object containing the plot.
+        """
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(12, 4))
+
+        # Get unique speakers and assign them y-positions and colors
+        speakers = sorted(set(self.speakers))
+        speaker_positions = {s: i for i, s in enumerate(speakers)}
+        colors = plt.cm.rainbow(np.linspace(0, 1, len(speakers)))
+        speaker_colors = dict(zip(speakers, colors))
+
+        # Calculate total speaking time for each speaker
+        speaker_durations = dict.fromkeys(speakers, 0)
+        for segment, _, speaker in self.itertracks(yield_label=True):
+            speaker_durations[speaker] += segment.duration
+
+        # Plot segments for each speaker
+        for segment, _, speaker in self.itertracks(yield_label=True):
+            ax.barh(
+                y=speaker_positions[speaker],
+                width=segment.duration,
+                left=segment.start,
+                height=0.8,
+                color=speaker_colors[speaker],
+                label=f"{speaker} ({speaker_durations[speaker]:.2f}s)",
+            )
+
+        # Clean up duplicate labels
+        handles, labels = ax.get_legend_handles_labels()
+        by_label = dict(zip(labels, handles))
+
+        # Move legend outside the plot to the right and add title
+        ax.legend(
+            by_label.values(),
+            by_label.keys(),
+            title="Speakers",
+            loc="center left",
+            bbox_to_anchor=(1, 0.5),
+        )
+
+        # Customize appearance
+        ax.set_yticks(list(speaker_positions.values()))
+        ax.set_yticklabels(list(speaker_positions.keys()))
+        ax.set_xlabel("Time (seconds)")
+        ax.grid(True, axis="x", alpha=0.3)
+
+        # Adjust layout to make room for legend
+        plt.tight_layout()
+        plt.subplots_adjust(right=0.85)
+
+        return ax
+
+    def fill_small_gaps(self, min_active_offset: float = 0.0) -> "DiarizationAnnotation":
+        """Fill small gaps between segments of the same speaker.
+
+        Args:
+            min_active_offset: Maximum gap duration (in seconds) to be filled.
+                             If the gap between two segments is smaller than this,
+                             they will be merged.
+
+        Returns:
+            A new DiarizationAnnotation with small gaps filled.
+        """
+        merged_annotation = DiarizationAnnotation(self.uri)
+
+        for speaker_label in self.labels():
+            speaker_annot = self.subset([speaker_label])
+            segments = list(speaker_annot.itersegments())
+
+            if not segments:
+                continue
+
+            current_segment = segments[0]
+            for next_segment in segments[1:]:
+                gap = next_segment.start - current_segment.end
+                if gap <= min_active_offset:
+                    # Merge segments
+                    logger.debug(f"Speaker {speaker_label}: Merging segments {current_segment} and {next_segment}")
+                    current_segment = Segment(current_segment.start, next_segment.end)
+                else:
+                    # Add current merged segment
+                    merged_annotation[current_segment] = speaker_label
+                    current_segment = next_segment
+
+            # Add the last segment
+            merged_annotation[current_segment] = speaker_label
+
+        return merged_annotation
 
 
 # ASR or Orchestration Prediction


### PR DESCRIPTION
# What does this PR do?

This PR adds `.plot` and `.fill_small_gaps` to `DiarizationAnnotation`. The new `.plot` method allows for a visualization different from the native `pyannote` `Annotation` viz. For example:

With pyannote default viz:

<img width="1570" height="242" alt="image" src="https://github.com/user-attachments/assets/faf4fde3-f7cf-4300-b825-93f149d38fe7" />

With new `.plot`

<img width="1230" height="390" alt="image" src="https://github.com/user-attachments/assets/70a18449-4ab9-4515-b7d3-d90c72f2b30c" />


It also allows for simple composition with `matplotlib` plots e.g.:

```python
import matplotlib.pyplot as plt

from openbench.dataset import DatasetRegistry
from openbench.types import PipelineType
from pyannote.core import Segment
from pyannote.metrics.diarization import DiarizationErrorRate

ds_config = DatasetRegistry.get_alias_config("ami-ihm")
ds = DatasetRegistry.get_dataset_for_pipeline(PipelineType.DIARIZATION, ds_config)

der_metric = DiarizationErrorRate()

p = DiarizationAnnotation.load_annotation_file(<path-to-prediction>)
mapping = der_metric.optimal_mapping(ds[1].reference, p)
p = p.rename_labels(mapping)


crop_segment = Segment(0, 20)

fig, axes = plt.subplots(2, 1, figsize=(10, 6))
ds[1].reference.crop(crop_segment).plot(ax=axes[0])
p.crop(crop_segment).fill_small_gaps(0.8).plot(ax=axes[1])

axes[0].set_title("Reference")
axes[1].set_title("Prediction")

# Ensure x-axis starts at 0 and ends at 30 for both subplots
for ax in axes:
    ax.set_xlim(0, crop_segment.end)
    # Add very thin and transparent vertical dashed lines for every 1 unit of x-axis
    for x in np.arange(0, crop_segment.end + 1, 0.5):
        ax.axvline(
            x, 
            color="gray", 
            linestyle="--", 
            linewidth=0.5, 
            alpha=0.2, 
            zorder=0
        )

plt.tight_layout()
plt.show()
```

<img width="990" height="590" alt="image" src="https://github.com/user-attachments/assets/1504d7bc-a0ad-4d7b-b044-85672e7de09c" />
