### PR TITLE
Add common-voice-ru as a dataset alias

### DIFF
--- a/src/openbench/dataset/dataset_aliases.py
+++ b/src/openbench/dataset/dataset_aliases.py
@@ -460,6 +460,16 @@ def register_dataset_aliases() -> None:
         description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only catalan",
     )
 
+    # Russian
+    DatasetRegistry.register_alias(
+        "common-voice-ru",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="ru"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only russian",
+    )
+
     ########## STREAMING TRANSCRIPTION ##########
 
     DatasetRegistry.register_alias(


### PR DESCRIPTION
# What does this PR do?

This PR adds a new dataset alias called `common-voice-ru` for easy access to the Russian subset of the [common-voice 400 samples](https://huggingface.co/datasets/argmaxinc/common_voice_17_0-argmax_subset-400-openbench)

Now, it is possible to:

```bash
uv run openbench-cli evaluate -p whisperkit-large-v3-turbo -d common-voice-ru -m wer
```