### PR TITLE
Save Config when running evaluation

### DIFF
--- a/src/openbench/pipeline/orchestration/orchestration_whisperkitpro.py
+++ b/src/openbench/pipeline/orchestration/orchestration_whisperkitpro.py
@@ -80,7 +80,7 @@ class WhisperKitProOrchestrationPipeline(Pipeline):
     def parse_input(self, input_sample: OrchestrationSample) -> WhisperKitProInput:
         return WhisperKitProInput(
             audio_path=input_sample.save_audio(TEMP_AUDIO_DIR),
-            keep_audio=True,
+            keep_audio=False,
         )
 
     def parse_output(self, output: WhisperKitProOutput) -> OrchestrationOutput:

--- a/src/openbench/runner/benchmark.py
+++ b/src/openbench/runner/benchmark.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 
 import tqdm
 import wandb
+import yaml
 from argmaxtools.utils import get_logger
 from pyannote.metrics.base import BaseMetric
 
@@ -303,6 +304,7 @@ class BenchmarkRunner:
 
         # Getting config to log to wandb
         wandb_config = self.config.get_wandb_config_to_log()
+
         for pipeline in self.pipelines:
             # Get logger
             wandb_logger = self.logger_map[pipeline.pipeline_type](output_dir=".")
@@ -324,6 +326,10 @@ class BenchmarkRunner:
                     config=wandb_config,
                 ),
             ):
+                # Save a copy of the wandb_config locally as a .yaml
+                with open("config.yaml", "w") as f:
+                    yaml.dump(wandb_config, f)
+
                 for dataset_name, dataset_config in self.config.datasets.items():
                     # Use DatasetRegistry to get the appropriate dataset for the pipeline type
                     ds = DatasetRegistry.get_dataset_for_pipeline(


### PR DESCRIPTION
# What does this PR do?

When running `openbench-cli evaluate ...`, we were not locally saving the configuration being used. This would only be logged if W&B is enabled. This PR fixes this by saving the configuration used locally as a `.yaml` file even when W&B is disabled.