### PR TITLE
Fix MSDWILD Alias

### DIFF
--- a/src/openbench/dataset/dataset_aliases.py
+++ b/src/openbench/dataset/dataset_aliases.py
@@ -34,7 +34,7 @@ def register_dataset_aliases() -> None:
 
     DatasetRegistry.register_alias(
         "msdwild",
-        DatasetConfig(dataset_id="argmaxinc/msdwild", split="test"),
+        DatasetConfig(dataset_id="argmaxinc/msdwild", split="validation"),
         supported_pipeline_types={
             PipelineType.DIARIZATION,
         },


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `msdwild` alias that previously was set to the incorrect (and non-existent) split