### PR TITLE
Add timeout option to deepgram engine

### DIFF
--- a/src/openbench/dataset/dataset_base.py
+++ b/src/openbench/dataset/dataset_base.py
@@ -59,7 +59,7 @@ class BaseSample(BaseModel, Generic[ReferenceType, ExtraInfoType]):
         if not isinstance(output_dir, Path):
             output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_path = output_dir / f"{self.audio_name}.wav"
+        output_path = output_dir / f"{self.audio_name}.flac"
         logger.info(f"Saving audio to {output_path}")
         sf.write(output_path, self.waveform, self.sample_rate)
         return output_path


### PR DESCRIPTION
# What does this PR do?

This PR adds `Timeout` to the `deepgram` engine when transcribing from pre-recorded files. This was preventing the evaluation on long-form datasets, e.g., `earnings21`