### PR TITLE
Register timit-stitched silence datasets

### DIFF
--- a/src/openbench/dataset/dataset_aliases.py
+++ b/src/openbench/dataset/dataset_aliases.py
@@ -511,5 +511,63 @@ def register_dataset_aliases() -> None:
         description="TIMIT stitched dataset for streaming transcription evaluation",
     )
 
+    ########## END POINTING TEST DATASETS ##########
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-short-silences-debug",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v1", split="train", num_samples=1),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched Debug dataset with short silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-medium-silences-debug",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v2", split="train", num_samples=1),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched Debug dataset with medium silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-long-silences-debug",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v3", split="train", num_samples=1),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched Debug dataset with long silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-very-long-silences-debug",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v4", split="train", num_samples=1),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched Debug dataset with very long silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-short-silences",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v1", split="train"),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched dataset with short silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-medium-silences",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v2", split="train"),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched dataset with medium silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-long-silences",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v3", split="train"),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched dataset with long silences for endpointing evals",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched-very-long-silences",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched_silenced-v4", split="train"),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched dataset with very long silences for endpointing evals",
+    )
+
 
 register_dataset_aliases()


### PR DESCRIPTION
This PR adds new timit-stitched datasets with **varying silence durations** to `openbench-cli`

**Newly Registered Datasets**

`timit-stitched-short-silences`: silences from 100 ms – 1 s

`timit-stitched-medium-silences`: silences from 100 ms – 5 s

`timit-stitched-long-silences`: silences from 1 – 5 s

`timit-stitched-very-long-silences`: silences from 2 – 10 s

**Debug Variants (single-sample)**

- `timit-stitched-short-silences-debug`
- `timit-stitched-medium-silences-debug`
- `timit-stitched-long-silences-debug`
- `timit-stitched-very-long-silences-debug`

**Example Usage**
```
openbench-cli evaluate \               
  --pipeline deepgram-streaming \
  --dataset timit-stitched-short-silences-debug \
  --metrics wer \
  -m streaming_latency
```