### PR TITLE
Update Gladia Streaming Pipeline for v2 migration

### DIFF
--- a/src/openbench/pipeline/streaming_transcription/gladia.py
+++ b/src/openbench/pipeline/streaming_transcription/gladia.py
@@ -42,10 +42,18 @@ class GladiaApi:
         global audio_cursor
         global confirmed_audio_cursor_l
         global predicted_transcript_hypot
+        global interim_transcripts_list
+        global audio_cursor_l
+        global model_timestamps_hypothesis
+        global cumulative_transcript
         predicted_transcript_hypot = ""
         confirmed_audio_cursor_l = []
+        interim_transcripts_list = []
+        audio_cursor_l = []
+        model_timestamps_hypothesis = []
         audio_cursor = 0
         confirmed_interim_transcripts = []
+        cumulative_transcript = ""
 
         class InitiateResponse(TypedDict):
             id: str
@@ -56,24 +64,36 @@ class GladiaApi:
             code_switching: bool | None
 
         class StreamingConfiguration(TypedDict):
-            # This is a reduced set of options. For a full list, see the API documentation.
+            # This is a reduced set of options. For a full list, see the API
+            # documentation.
             # https://docs.gladia.io/api-reference/v2/live/init
             encoding: Literal["wav/pcm", "wav/alaw", "wav/ulaw"]
             bit_depth: Literal[8, 16, 24, 32]
-            sample_rate: Literal[8_000, 16_000, 32_000, 44_100, 48_000]
+            sample_rate: Literal[
+                8_000, 16_000, 32_000, 44_100, 48_000
+            ]
             channels: int
             language_config: LanguageConfiguration | None
 
         def init_live_session(config: StreamingConfiguration) -> InitiateResponse:
             response = requests.post(
                 self.api_endpoint_base_url,
-                headers={"X-Gladia-Key": self.api_key},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Gladia-Key": self.api_key
+                },
                 json=config,
-                timeout=3,
+                timeout=10,
             )
             if not response.ok:
-                print(f"{response.status_code}: {response.text or response.reason}")
-                exit(response.status_code)
+                error_text = response.text or response.reason
+                error_message = f"{response.status_code}: {error_text}"
+                logger.error(
+                    f"Failed to initialize Gladia live session: {error_message}"
+                )
+                raise RuntimeError(
+                    f"Gladia API initialization failed: {error_message}"
+                )
             return response.json()
 
         def format_duration(seconds: float) -> str:
@@ -90,40 +110,109 @@ class GladiaApi:
             global audio_cursor
             global confirmed_audio_cursor_l
             global model_timestamps_confirmed
+            global predicted_transcript_hypot
+            global interim_transcripts_list
+            global audio_cursor_l
+            global model_timestamps_hypothesis
+            global cumulative_transcript
             model_timestamps_confirmed = []
             final_transcript = ""
-            async for message in socket:
-                content = json.loads(message)
-                if content["type"] == "transcript":
-                    confirmed_audio_cursor_l.append(audio_cursor)
-                    text = content["data"]["utterance"]["text"].strip()
-                    confirmed_interim_transcripts.append(text)
-                    model_timestamps_confirmed.append(content["data"]["utterance"]["words"])
-                    logger.debug("\n" + "Transcription: " + content["data"]["utterance"]["text"].strip())
-                if content["type"] == "post_final_transcript":
-                    logger.debug("\n################ End of session ################\n")
-                    final_transcript = content["data"]["transcription"]["full_transcript"]
+
+            try:
+                async for message in socket:
+                    try:
+                        content = json.loads(message)
+                        message_type = content.get("type")
+                        if message_type == "transcript":
+                            data = content.get("data", {})
+                            utterance = data.get("utterance", {})
+                            text = utterance.get("text", "").strip()
+                            words = utterance.get("words", [])
+                            is_final = data.get("is_final", True)
+                            if text:
+                                if not is_final:
+                                    # Only track interim transcripts with valid timestamps
+                                    if (words and len(words) > 0 and 
+                                        all("start" in word and "end" in word 
+                                            for word in words)):
+                                        cumulative_with_new = (
+                                            cumulative_transcript + " " + text
+                                            if cumulative_transcript else text
+                                        ).strip()
+                                        interim_transcripts_list.append(
+                                            cumulative_with_new
+                                        )
+                                        audio_cursor_l.append(audio_cursor)
+                                        model_timestamps_hypothesis.append(words)
+                                        predicted_transcript_hypot = text
+                                        logger.debug(f"Interim transcript: {text}")
+                                else:
+                                    confirmed_audio_cursor_l.append(
+                                        audio_cursor
+                                    )
+                                    # Update cumulative transcript
+                                    cumulative_transcript = (
+                                        cumulative_transcript + " " + text
+                                        if cumulative_transcript else text
+                                    ).strip()
+                                    confirmed_interim_transcripts.append(
+                                        cumulative_transcript
+                                    )
+                                    model_timestamps_confirmed.append(words)
+                                    logger.debug(f"Final transcript: {text}")
+                        elif message_type == "post_final_transcript":
+                            logger.debug(
+                                "\n#### End of Gladia v2 session ####\n"
+                            )
+                            transcription_data = content.get(
+                                "data", {}
+                            ).get("transcription", {})
+                            final_transcript = transcription_data.get(
+                                "full_transcript", ""
+                            )
+                        else:
+                            logger.debug(
+                                f"Received message type: {message_type}"
+                            )
+                    except (json.JSONDecodeError, KeyError) as e:
+                        logger.warning(
+                            f"Failed to parse message from Gladia: {e}"
+                        )
+                        continue
+            except Exception as e:
+                logger.error(
+                    f"Error reading messages from Gladia websocket: {e}"
+                )
+                raise
 
         async def stop_recording(websocket: ClientConnection) -> None:
-            logger.debug(">>>>> Ending the recording…")
             await websocket.send(json.dumps({"type": "stop_recording"}))
             await asyncio.sleep(0)
 
         STREAMING_CONFIGURATION: StreamingConfiguration = {
-            # This configuration is for a 16kHz, 16-bit, mono PCM WAV file
             "encoding": "wav/pcm",
-            "sample_rate": 16_000,
-            "bit_depth": 16,
-            "channels": 1,
+            "sample_rate": self.sample_rate,
+            "bit_depth": self.sample_width * 8,
+            "channels": self.channels,
             "language_config": {
                 "languages": ["es", "ru", "en", "fr"],
                 "code_switching": True,
             },
+            "messages_config": {
+                                "receive_partial_transcripts": True,
+                                "receive_final_transcripts": True,
+                                "receive_speech_events": True,
+                                "receive_pre_processing_events": False,
+                                "receive_realtime_processing_events": True,
+                                "receive_post_processing_events": False,
+                                "receive_acknowledgments": False,
+                                "receive_lifecycle_events": False                    
+                                }
         }
 
         async def send_audio(socket: ClientConnection, data) -> None:
             global audio_cursor
-            audio_duration_in_seconds = 0.1
+            audio_duration_in_seconds = self.chunk_size_ms / 1000.0
             chunk_size = int(
                 STREAMING_CONFIGURATION["sample_rate"]
                 * (STREAMING_CONFIGURATION["bit_depth"] / 8)
@@ -131,13 +220,18 @@ class GladiaApi:
                 * audio_duration_in_seconds
             )
 
-            # Send the audio file in chunks
             offset = 0
             while offset < len(data):
                 try:
-                    await socket.send(data[offset : offset + chunk_size])
-                    offset += chunk_size
-                    audio_cursor += audio_duration_in_seconds
+                    actual_chunk_size = min(chunk_size, len(data) - offset)
+                    await socket.send(data[offset: offset + actual_chunk_size])
+                    offset += actual_chunk_size
+                    actual_audio_duration = actual_chunk_size / (
+                        STREAMING_CONFIGURATION["sample_rate"]
+                        * (STREAMING_CONFIGURATION["bit_depth"] / 8)
+                        * STREAMING_CONFIGURATION["channels"]
+                    )
+                    audio_cursor += actual_audio_duration
                     await asyncio.sleep(audio_duration_in_seconds)
                 except ConnectionClosedOK:
                     return
@@ -145,30 +239,53 @@ class GladiaApi:
             await stop_recording(socket)
 
         async def main(data):
-            response = init_live_session(STREAMING_CONFIGURATION)
-            async with connect(response["url"]) as websocket:
+            try:
+                response = init_live_session(STREAMING_CONFIGURATION)
+                websocket_url = response["url"]
+                logger.debug(f"Received websocket URL from Gladia API: {websocket_url}")
+            except Exception as e:
+                logger.error(f"Failed to initialize Gladia session: {e}")
+                raise
+            async with connect(websocket_url) as websocket:
                 try:
-                    logger.debug("\n################ Begin session ################\n")
+                    logger.debug(
+                        "\n#### Begin Gladia session ####\n"
+                    )
                     tasks = []
-                    tasks.append(asyncio.create_task(send_audio(websocket, data)))
-                    tasks.append(asyncio.create_task(print_messages_from_socket(websocket)))
+                    tasks.append(
+                        asyncio.create_task(send_audio(websocket, data))
+                    )
+                    tasks.append(
+                        asyncio.create_task(
+                            print_messages_from_socket(websocket)
+                        )
+                    )
 
                     await asyncio.wait(tasks)
                 except asyncio.exceptions.CancelledError:
+                    logger.debug("Tasks cancelled, cleaning up...")
                     for task in tasks:
                         task.cancel()
                     await stop_recording(websocket)
                     await print_messages_from_socket(websocket)
+                except Exception as e:
+                    logger.error(
+                        f"Error during websocket communication: {e}"
+                    )
+                    raise
 
         asyncio.run(main(data))
 
         return (
-            final_transcript,
-            None,
-            None,  # no hypothesis text is provided by Gladia
+            final_transcript if final_transcript else cumulative_transcript,
+            (interim_transcripts_list
+             if interim_transcripts_list else None),
+            (audio_cursor_l
+             if audio_cursor_l else None),
             confirmed_interim_transcripts,
             confirmed_audio_cursor_l,
-            None,
+            (model_timestamps_hypothesis
+             if model_timestamps_hypothesis else None),
             model_timestamps_confirmed,
         )
 
@@ -185,7 +302,7 @@ class GladiaApi:
         ) = self.run(sample)
         return {
             "transcript": transcript,
-            "interim_transcripts": interim_transcripts,  # no hypothesis text is provided by Gladia
+            "interim_transcripts": interim_transcripts,
             "audio_cursor": audio_cursor_l,
             "confirmed_interim_transcripts": confirmed_interim_transcripts,
             "confirmed_audio_cursor": confirmed_audio_cursor_l,


### PR DESCRIPTION
This PR updates the `GladiaStreamingPipeline` to support the migration from `Gladia API v1 → v2`.

**Key Changes**
- Migrated pipeline logic to align with v2 API.
- Added support for interim transcription results, enabling partial outputs before final confirmation.

**Testing Instructions**

**Enviroment Setup**
```
conda create -n test_gladia python=3.10
conda activate test_gladia
pip install -e .
```
**Example CLI Command**
```
openbench-cli evaluate \                     
    --pipeline gladia-streaming \
    --dataset timit-debug \
    --metrics wer \
    -m confirmed_streaming_latency \
    -m streaming_latency \
    -m number_substitutions \
    -m number_deletions \
    -m number_insertions
```

**Example CLI Command Results**

<img width="600" height="167" alt="Screenshot 2025-09-19 at 3 55 47 PM" src="https://github.com/user-attachments/assets/b24fb95c-932b-4584-a00c-f6e800d28951" />


