### PR TITLE
Add Footnote Explaining Faster Latency Configuration

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -265,19 +265,19 @@
 - **Code Reference:** [openbench/pipeline/streaming_transcription/gladia](https://github.com/argmaxinc/OpenBench/blob/main/src/openbench/pipeline/streaming_transcription/gladia.py)
 - **Hardware**: Unknown (Cloud API)
 
-### Argmax (Parakeet V2)
+### Argmax (Parakeet V2)¹
 - **Latest Run:** `09-12-2025`
 - **Configuration:** Reuses the Deepgram pipeline with `DEEPGRAM_HOST_URL=ws://localhost:port` while [Argmax Local Server](https://www.argmaxinc.com/blog/argmax-local-server) is running with our compressed optimized model `--model parakeet-v2_476MB` at `ws://localhost:port`
 - **Code Reference:** [openbench/pipeline/streaming_transcription/deepgram](https://github.com/argmaxinc/OpenBench/blob/main/src/openbench/pipeline/streaming_transcription/deepgram.py)
 - **Hardware**: M2 Ultra Mac Studio
 
-### Argmax (Parakeet V3)
+### Argmax (Parakeet V3)¹
 - **Latest Run:** `09-12-2025`
 - **Configuration:** Reuses the Deepgram pipeline with `DEEPGRAM_HOST_URL=ws://localhost:port` while [Argmax Local Server](https://www.argmaxinc.com/blog/argmax-local-server) is running with our compressed optimized model `--model parakeet-v3_494MB` at `ws://localhost:port`
 - **Code Reference:** [openbench/pipeline/streaming_transcription/deepgram](https://github.com/argmaxinc/OpenBench/blob/main/src/openbench/pipeline/streaming_transcription/deepgram.py)
 - **Hardware**: M2 Ultra Mac Studio
 
-### Argmax (Whisper Large V3 Turbo)
+### Argmax (Whisper Large V3 Turbo)¹
 - **Latest Run:** `09-12-2025`
 - **Configuration:** Reuses the Deepgram pipeline with `DEEPGRAM_HOST_URL=ws://localhost:port` while [Argmax Local Server](https://www.argmaxinc.com/blog/argmax-local-server) is running with our compressed optimized model `--model large-v3-v20240930_626MB` at `ws://localhost:port`
 - **Code Reference:** [openbench/pipeline/streaming_transcription/deepgram](https://github.com/argmaxinc/OpenBench/blob/main/src/openbench/pipeline/streaming_transcription/deepgram.py)
@@ -321,7 +321,7 @@
 </details>
 
 
-| Dataset        | Deepgram<br/>(nova-3) | OpenAI <br/>(GPT-4o) | Gladia |  Argmax <br/>(Parakeet V2) |  Argmax <br/>(Parakeet V3) | Argmax <br/>(Whisper Large V3 Turbo) |
+| Dataset        | Deepgram<br/>(nova-3) | OpenAI <br/>(GPT-4o) | Gladia |  Argmax¹ <br/>(Parakeet V2) |  Argmax¹ <br/>(Parakeet V3) | Argmax¹ <br/>(Whisper Large V3 Turbo) |
 |----------------|----------|-----------------|----------------------------|---------------------------------------|---------------------------------------|---------------------------------------|
 | Short-form (timit) | 0.67  | N/A  | 0.56 | 0.38 | 0.39 | 1.04  |
 | Long-form <br/>(timit-stitched) | 1.03 | N/A | 0.64  | 0.54 | 0.55 | 0.94  |
@@ -342,7 +342,11 @@
 
 </details>
 
-| Dataset        | Deepgram<br/>(nova-3) | OpenAI <br/>(GPT-4o) | Gladia |  Argmax <br/>(Parakeet V2) |  Argmax <br/>(Parakeet V3) | Argmax <br/>(Whisper Large V3 Turbo) |
+| Dataset        | Deepgram<br/>(nova-3) | OpenAI <br/>(GPT-4o) | Gladia |  Argmax¹ <br/>(Parakeet V2) |  Argmax¹ <br/>(Parakeet V3) | Argmax¹ <br/>(Whisper Large V3 Turbo) |
 |----------------|----------|-----------------|----------------------------|---------------------------------------|---------------------------------------|---------------------------------------|
 | Short-form (timit) | 1.64  | 1.68  | 1.75 | 1.82 | 1.82 | 1.54  |
 | Long-form <br/>(timit-stitched) | 2.37 | 56.95 | 2.72  | 5.51 | 5.96 | 2.51  |
+
+---
+
+¹ **Note:** This is not the fastest configuration for Argmax streaming transcription. The system sleeps for 0.3s to get enough audio and can be configured to be faster by another 0.3s.


### PR DESCRIPTION
This PR adds a footnote to `benchmarks.md` clarifying that the latest streaming results were not obtained with the fastest configuration, and performance could be higher under a different configuration