### PR TITLE
Add AssemblyAI Benchmarks

### DIFF
--- a/config/pipeline_configs/AssemblyAIStreamingPipeline.yaml
+++ b/config/pipeline_configs/AssemblyAIStreamingPipeline.yaml
@@ -1,0 +1,7 @@
+AssemblyAIStreamingPipeline:
+  config:
+    sample_rate: 16000
+    channels: 1
+    sample_width: 2
+    chunksize_ms: 50
+    endpoint_url: "wss://streaming.assemblyai.com/v3/ws"

--- a/config/pipeline_configs/AssemblyAITranscriptionPipeline.yaml
+++ b/config/pipeline_configs/AssemblyAITranscriptionPipeline.yaml
@@ -1,8 +1,4 @@
 AssemblyAITranscriptionPipeline:
   config:
-    sample_rate: 16000
-    channels: 1
-    sample_width: 2
-    chunksize_ms: 50
-    endpoint_url: "wss://streaming.assemblyai.com/v3/ws"
+    model_version: "universal"
     use_keywords: true

--- a/config/pipeline_configs/AssemblyAITranscriptionPipeline.yaml
+++ b/config/pipeline_configs/AssemblyAITranscriptionPipeline.yaml
@@ -1,0 +1,8 @@
+AssemblyAITranscriptionPipeline:
+  config:
+    sample_rate: 16000
+    channels: 1
+    sample_width: 2
+    chunksize_ms: 50
+    endpoint_url: "wss://streaming.assemblyai.com/v3/ws"
+    use_keywords: true

--- a/src/openbench/pipeline/pipeline_aliases.py
+++ b/src/openbench/pipeline/pipeline_aliases.py
@@ -21,12 +21,14 @@ from .orchestration import (
 )
 from .pipeline_registry import PipelineRegistry
 from .streaming_transcription import (
+    AssemblyAIStreamingPipeline,
     DeepgramStreamingPipeline,
     FireworksStreamingPipeline,
     GladiaStreamingPipeline,
     OpenAIStreamingPipeline,
 )
 from .transcription import (
+    AssemblyAITranscriptionPipeline,
     DeepgramTranscriptionPipeline,
     GroqTranscriptionPipeline,
     NeMoTranscriptionPipeline,
@@ -473,6 +475,20 @@ def register_pipeline_aliases() -> None:
         description="NeMo CTC transcription with context biasing for keyword spotting. Local model, no API key required.",
     )
 
+    PipelineRegistry.register_alias(
+        "assemblyai-transcription",
+        AssemblyAITranscriptionPipeline,
+        default_config={
+            "sample_rate": 16000,
+            "channels": 1,
+            "sample_width": 2,
+            "chunksize_ms": 50,
+            "endpoint_url": "wss://streaming.assemblyai.com/v3/ws",
+            "use_keywords": False,
+        },
+        description="AssemblyAI transcription pipeline with keyword boosting support. Requires API key from https://www.assemblyai.com/. Set `ASSEMBLYAI_API_KEY` env var.",
+    )
+
     ################# STREAMING TRANSCRIPTION PIPELINES #################
 
     PipelineRegistry.register_alias(
@@ -528,6 +544,19 @@ def register_pipeline_aliases() -> None:
             "model": "gpt-4o-transcribe",
         },
         description="OpenAI streaming transcription pipeline. Requires API key from https://www.openai.com/. Set `OPENAI_API_KEY` env var.",
+    )
+
+    PipelineRegistry.register_alias(
+        "assemblyai-streaming",
+        AssemblyAIStreamingPipeline,
+        default_config={
+            "sample_rate": 16000,
+            "channels": 1,
+            "sample_width": 2,
+            "chunksize_ms": 50,
+            "endpoint_url": "wss://streaming.assemblyai.com/v3/ws",
+        },
+        description="AssemblyAI streaming transcription pipeline. Requires API key from https://www.assemblyai.com/. Set `ASSEMBLYAI_API_KEY` env var.",
     )
 
 

--- a/src/openbench/pipeline/pipeline_aliases.py
+++ b/src/openbench/pipeline/pipeline_aliases.py
@@ -479,11 +479,7 @@ def register_pipeline_aliases() -> None:
         "assemblyai-transcription",
         AssemblyAITranscriptionPipeline,
         default_config={
-            "sample_rate": 16000,
-            "channels": 1,
-            "sample_width": 2,
-            "chunksize_ms": 50,
-            "endpoint_url": "wss://streaming.assemblyai.com/v3/ws",
+            "model_version": "universal",
             "use_keywords": False,
         },
         description="AssemblyAI transcription pipeline with keyword boosting support. Requires API key from https://www.assemblyai.com/. Set `ASSEMBLYAI_API_KEY` env var.",

--- a/src/openbench/pipeline/streaming_transcription/__init__.py
+++ b/src/openbench/pipeline/streaming_transcription/__init__.py
@@ -1,6 +1,7 @@
 # For licensing see accompanying LICENSE.md file.
 # Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
 
+from .assemblyai import AssemblyAIStreamingPipeline, AssemblyAIStreamingPipelineConfig
 from .deepgram import DeepgramStreamingPipeline, DeepgramStreamingPipelineConfig
 from .fireworks import FireworksStreamingPipeline, FireworksStreamingPipelineConfig
 from .gladia import GladiaStreamingPipeline, GladiaStreamingPipelineConfig

--- a/src/openbench/pipeline/streaming_transcription/assemblyai.py
+++ b/src/openbench/pipeline/streaming_transcription/assemblyai.py
@@ -1,0 +1,268 @@
+import json
+import os
+import threading
+import time
+from urllib.parse import urlencode
+
+import torch
+import torchaudio
+import websocket
+from argmaxtools.utils import get_logger
+
+from ...dataset import StreamingSample
+from ...pipeline import Pipeline, register_pipeline
+from ...pipeline_prediction import StreamingTranscript
+from ...types import PipelineType
+from .common import StreamingTranscriptionConfig, StreamingTranscriptionOutput
+
+logger = get_logger(__name__)
+
+
+class AssemblyAIApi:
+    def __init__(self, cfg) -> None:
+        self.chunk_size_ms = cfg.chunksize_ms
+        self.api_key = os.getenv("ASSEMBLYAI_API_KEY")
+        assert self.api_key is not None, "Please set ASSEMBLYAI_API_KEY in environment"
+        self.channels = cfg.channels
+        self.sample_width = cfg.sample_width
+        self.sample_rate = cfg.sample_rate
+        CONNECTION_PARAMS = {
+            "sample_rate": self.sample_rate,
+            "format_turns": False,
+        }
+        self.api_endpoint_base_url = cfg.endpoint_url
+        self.api_endpoint = (
+            f"{self.api_endpoint_base_url}?{urlencode(CONNECTION_PARAMS)}"
+        )
+
+    def scale_model_timestamps(self, timestamps):
+        for sublist in timestamps:
+            for item in sublist:
+                item["start"] /= 1000
+                item["end"] /= 1000
+        return timestamps
+
+    def run(self, data):
+        global interim_transcripts
+        global audio_cursor
+        global audio_cursor_l
+        global segments_hypot
+        global lock
+        global predicted_transcript_hypot
+        global confirmed_interim_transcripts
+        global model_timestamps_hypot
+        global model_timestamps_confirmed
+        audio_cursor_l = []
+        audio_cursor = 0
+        interim_transcripts = []
+        confirmed_interim_transcripts = []
+        model_timestamps_confirmed = []
+        model_timestamps_hypot = []
+        lock = threading.Lock()
+        segments_hypot = {}
+        segments = {}
+
+        def on_open(ws):
+            def stream_audio(ws):
+                global audio_cursor
+                for chunk in data:
+                    ws.send(chunk, opcode=websocket.ABNF.OPCODE_BINARY)
+                    time.sleep(self.chunk_size_ms / 1000)
+                    audio_cursor += self.chunk_size_ms / 1000
+
+                final_checkpoint = json.dumps({"type": "Terminate"})
+                ws.send(final_checkpoint, opcode=websocket.ABNF.OPCODE_TEXT)
+
+            threading.Thread(target=stream_audio, args=(ws,)).start()
+
+        def on_error(ws, error):
+            print(f"Error: {error}")
+
+        def on_message(ws, message):
+            global predicted_transcript_hypot
+            global audio_cursor
+            global audio_cursor_l
+            global interim_transcripts
+            global confirmed_interim_transcripts
+            global model_timestamps_hypot
+            global model_timestamps_confirmed
+            try:
+                data = json.loads(message)
+                msg_type = data.get("type")
+                if msg_type == "Turn":
+                    if data["transcript"] != "":
+                        audio_cursor_l.append(audio_cursor)
+                        model_timestamps_confirmed.append(
+                            [
+                                item
+                                for item in data["words"]
+                                if item.get("word_is_final", True)
+                            ]
+                        )
+                        model_timestamps_hypot.append([item for item in data["words"]])
+                        updated_segments_hypot = {
+                            data["turn_order"]: " ".join(
+                                word["text"] for word in data["words"]
+                            )
+                        }
+                        updated_segments = {data["turn_order"]: data["transcript"]}
+
+                        with lock:
+                            segments.update(updated_segments)
+                            confirmed_predicted_transcript = " ".join(
+                                v for k, v in segments.items()
+                            )
+                            confirmed_interim_transcripts.append(
+                                confirmed_predicted_transcript
+                            )
+
+                        with lock:
+                            segments_hypot.update(updated_segments_hypot)
+                            predicted_transcript_hypot = " ".join(
+                                v for k, v in segments_hypot.items()
+                            )
+                            logger.debug(
+                                "\n" + "Transcription: " + predicted_transcript_hypot
+                            )
+                            interim_transcripts.append(predicted_transcript_hypot)
+
+                elif msg_type == "Termination":
+                    audio_duration = data.get("audio_duration_seconds", 0)
+                    session_duration = data.get("session_duration_seconds", 0)
+                    print(
+                        f"Session Terminated: Audio Duration={audio_duration}s, Session Duration={session_duration}s"
+                    )
+            except json.JSONDecodeError as e:
+                print(f"Error decoding message: {e}")
+            except Exception as e:
+                print(f"Error handling message: {e}")
+
+        ws = websocket.WebSocketApp(
+            self.api_endpoint,
+            header={"Authorization": self.api_key},
+            on_open=on_open,
+            on_message=on_message,
+            on_error=on_error,
+        )
+
+        ws.run_forever()
+
+        return (
+            predicted_transcript_hypot,
+            interim_transcripts,
+            audio_cursor_l,
+            confirmed_interim_transcripts,
+            audio_cursor_l,
+            model_timestamps_hypot,
+            model_timestamps_confirmed,
+        )
+
+    def __call__(self, sample):
+        # Sample must be in bytes
+        (
+            transcript,
+            interim_transcripts,
+            audio_cursor_l,
+            confirmed_interim_transcripts,
+            confirmed_audio_cursor_l,
+            model_timestamps_hypot,
+            model_timestamps_confirmed,
+        ) = self.run(sample)
+        model_timestamps_hypot = self.scale_model_timestamps(model_timestamps_hypot)
+        # TODO: scaling model_timestamps_hypot also scales model_timestamps_confirmed
+        # consider decoupling shared variables
+        # model_timestamps_confirmed = self.scale_model_timestamps(model_timestamps_confirmed)
+        return {
+            "transcript": transcript,
+            "interim_transcripts": interim_transcripts,
+            "audio_cursor": audio_cursor_l,
+            "confirmed_interim_transcripts": confirmed_interim_transcripts,
+            "confirmed_audio_cursor": confirmed_audio_cursor_l,
+            "model_timestamps_hypot": model_timestamps_hypot,
+            "model_timestamps_confirmed": model_timestamps_confirmed,
+        }
+
+
+class AssemblyAIStreamingPipelineConfig(StreamingTranscriptionConfig):
+    sample_rate: int = 16000
+    channels: int = 1
+    sample_width: int = 2
+    chunksize_ms: float = 50
+    endpoint_url: str = "wss://streaming.assemblyai.com/v3/ws"
+
+
+@register_pipeline
+class AssemblyAIStreamingPipeline(Pipeline):
+    _config_class = AssemblyAIStreamingPipelineConfig
+    pipeline_type = PipelineType.STREAMING_TRANSCRIPTION
+
+    def audio2chunks(self, audio_data):
+        audio_data = audio_data[None, :]
+        # Resample to 16000 Hz
+        target_sample_rate = 16000
+        audio_data = torchaudio.functional.resample(
+            torch.Tensor(audio_data), self.config.sample_rate, target_sample_rate
+        )
+        print(
+            f"Resampled audio tensor. shape={audio_data.shape} \
+            sample_rate={target_sample_rate}"
+        )
+
+        # Convert to mono
+        audio_tensor = torch.Tensor(audio_data).mean(dim=0, keepdim=True)
+        print(f"Mono audio tensor. shape={audio_tensor.shape}")
+
+        audio_chunk_tensors = torch.split(
+            audio_tensor,
+            int(self.config.chunksize_ms * target_sample_rate / 1000),
+            dim=1,
+        )
+        print(
+            f"Split into {len(audio_chunk_tensors)} audio \
+            chunks each {self.config.chunksize_ms}ms"
+        )
+
+        audio_chunk_bytes = []
+        for audio_chunk_tensor in audio_chunk_tensors:
+            audio_chunk_bytes.append(
+                (audio_chunk_tensor * 32768.0).to(torch.int16).numpy().tobytes()
+            )
+
+        return audio_chunk_bytes
+
+    def parse_input(self, input_sample: StreamingSample):
+        y = input_sample.waveform
+        audio_data_byte = self.audio2chunks(y)
+        return audio_data_byte
+
+    def parse_output(self, output) -> StreamingTranscriptionOutput:
+        model_timestamps_hypothesis = output["model_timestamps_hypot"]
+        model_timestamps_confirmed = output["model_timestamps_confirmed"]
+
+        # Filter to only include start and end timestamps, removing text/word fields
+        if model_timestamps_hypothesis is not None:
+            model_timestamps_hypothesis = [
+                [{"start": word["start"], "end": word["end"]} for word in interim_result_words if "start" in word and "end" in word]
+                for interim_result_words in model_timestamps_hypothesis
+            ]
+
+        if model_timestamps_confirmed is not None:
+            model_timestamps_confirmed = [
+                [{"start": word["start"], "end": word["end"]} for word in interim_result_words if "start" in word and "end" in word]
+                for interim_result_words in model_timestamps_confirmed
+            ]
+
+        prediction = StreamingTranscript(
+            transcript=output["transcript"],
+            audio_cursor=output["audio_cursor"],
+            interim_results=output["interim_transcripts"],
+            confirmed_audio_cursor=output["confirmed_audio_cursor"],
+            confirmed_interim_results=output["confirmed_interim_transcripts"],
+            model_timestamps_hypothesis=model_timestamps_hypothesis,
+            model_timestamps_confirmed=model_timestamps_confirmed,
+        )
+        return StreamingTranscriptionOutput(prediction=prediction)
+
+    def build_pipeline(self):
+        pipeline = AssemblyAIApi(self.config)
+        return pipeline

--- a/src/openbench/pipeline/transcription/__init__.py
+++ b/src/openbench/pipeline/transcription/__init__.py
@@ -3,6 +3,7 @@
 
 from .apple_speech_analyzer import SpeechAnalyzerConfig, SpeechAnalyzerPipeline
 from .common import TranscriptionOutput
+from .transcription_assemblyai import AssemblyAITranscriptionPipelineConfig, AssemblyAITranscriptionPipeline
 from .transcription_groq import GroqTranscriptionConfig, GroqTranscriptionPipeline
 from .transcription_whisperkitpro import WhisperKitProTranscriptionConfig, WhisperKitProTranscriptionPipeline
 from .whisperkit import WhisperKitTranscriptionConfig, WhisperKitTranscriptionPipeline
@@ -15,6 +16,8 @@ __all__ = [
     "TranscriptionOutput",
     "SpeechAnalyzerPipeline",
     "SpeechAnalyzerConfig",
+    "AssemblyAITranscriptionPipeline",
+    "AssemblyAITranscriptionPipelineConfig",
     "WhisperKitTranscriptionPipeline",
     "WhisperKitTranscriptionConfig",
     "WhisperKitProTranscriptionPipeline",

--- a/src/openbench/pipeline/transcription/transcription_assemblyai.py
+++ b/src/openbench/pipeline/transcription/transcription_assemblyai.py
@@ -29,21 +29,19 @@ class AssemblyAIApi:
 
     def transcribe(self, audio_path: Path, keywords=None):
         """Transcribe audio file using AssemblyAI REST API."""
-        
-        # First, upload the audio file
+
         with open(audio_path, "rb") as f:
             upload_response = requests.post(
                 f"{self.base_url}/v2/upload",
                 headers=self.headers,
                 data=f
             )
-            
+ 
         if upload_response.status_code != 200:
             raise RuntimeError(f"Upload failed: {upload_response.status_code}, {upload_response.text}")
-            
+
         upload_url = upload_response.json()["upload_url"]
-        
-        # Prepare transcription request
+
         data = {
             "audio_url": upload_url,
             "speech_model": self.model_version

--- a/src/openbench/pipeline/transcription/transcription_assemblyai.py
+++ b/src/openbench/pipeline/transcription/transcription_assemblyai.py
@@ -1,0 +1,229 @@
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urlencode
+
+import torch
+import torchaudio
+import websocket
+from argmaxtools.utils import get_logger
+
+from ...dataset import TranscriptionSample
+from ...pipeline import Pipeline, register_pipeline
+from ...pipeline_prediction import Transcript
+from ...types import PipelineType
+from .common import TranscriptionConfig, TranscriptionOutput
+
+logger = get_logger(__name__)
+
+TEMP_AUDIO_DIR = Path("temp_audio_dir")
+
+
+class AssemblyAIApi:
+    def __init__(self, cfg) -> None:
+        self.api_key = os.getenv("ASSEMBLYAI_API_KEY")
+        assert self.api_key is not None, "Please set ASSEMBLYAI_API_KEY in environment"
+        
+        self.sample_rate = cfg.sample_rate
+        self.channels = cfg.channels
+        self.sample_width = cfg.sample_width
+        self.chunksize_ms = cfg.chunksize_ms
+        self.api_endpoint_base_url = cfg.endpoint_url
+
+    def get_api_endpoint(self, keywords=None):
+        """Build API endpoint with optional keywords."""
+        CONNECTION_PARAMS = {
+            "sample_rate": self.sample_rate,
+            "format_turns": True,  # Request formatted final transcripts
+        }
+
+        # Add keywords if provided
+        if keywords:
+            CONNECTION_PARAMS["keyterms_prompt"] = json.dumps(keywords)
+
+        return f"{self.api_endpoint_base_url}?{urlencode(CONNECTION_PARAMS)}"
+
+    def run(self, audio_chunks, keywords=None):
+        """Run transcription on audio chunks."""
+        transcript_parts = []
+        session_complete = threading.Event()
+        error_occurred = threading.Event()
+        error_message = None
+        
+        # Get API endpoint with keywords
+        api_endpoint = self.get_api_endpoint(keywords)
+
+        def on_open(ws):
+            def stream_audio(ws):
+                try:
+                    for chunk in audio_chunks:
+                        if error_occurred.is_set():
+                            break
+                        ws.send(chunk, opcode=websocket.ABNF.OPCODE_BINARY)
+                        time.sleep(self.chunksize_ms / 1000)
+                    
+                    # Send termination message
+                    terminate_message = json.dumps({"type": "Terminate"})
+                    ws.send(terminate_message, opcode=websocket.ABNF.OPCODE_TEXT)
+                except Exception as e:
+                    logger.error(f"Error streaming audio: {e}")
+                    nonlocal error_message
+                    error_message = str(e)
+                    error_occurred.set()
+
+            threading.Thread(target=stream_audio, args=(ws,)).start()
+
+        def on_message(ws, message):
+            nonlocal error_message
+            try:
+                data = json.loads(message)
+                msg_type = data.get("type")
+                
+                if msg_type == "Begin":
+                    session_id = data.get('id')
+                    logger.debug(f"Session began: ID={session_id}")
+                    
+                elif msg_type == "Turn":
+                    transcript = data.get('transcript', '')
+                    formatted = data.get('turn_is_formatted', False)
+                    
+                    if formatted and transcript.strip():
+                        transcript_parts.append(transcript.strip())
+                        logger.debug(f"Received transcript: {transcript}")
+                        
+                elif msg_type == "Termination":
+                    audio_duration = data.get('audio_duration_seconds', 0)
+                    session_duration = data.get('session_duration_seconds', 0)
+                    logger.debug(f"Session terminated: Audio={audio_duration}s, Session={session_duration}s")
+                    session_complete.set()
+                    
+            except json.JSONDecodeError as e:
+                logger.error(f"Error decoding message: {e}")
+                error_message = f"JSON decode error: {e}"
+                error_occurred.set()
+            except Exception as e:
+                logger.error(f"Error handling message: {e}")
+                error_message = f"Message handling error: {e}"
+                error_occurred.set()
+
+        def on_error(ws, error):
+            nonlocal error_message
+            logger.error(f"WebSocket error: {error}")
+            error_message = f"WebSocket error: {error}"
+            error_occurred.set()
+
+        def on_close(ws, close_status_code, close_msg):
+            logger.debug(f"WebSocket closed: Status={close_status_code}, Msg={close_msg}")
+            session_complete.set()
+
+        # Create and run WebSocket connection
+        ws = websocket.WebSocketApp(
+            api_endpoint,
+            header={"Authorization": self.api_key},
+            on_open=on_open,
+            on_message=on_message,
+            on_error=on_error,
+            on_close=on_close,
+        )
+
+        # Run WebSocket in a separate thread
+        ws_thread = threading.Thread(target=ws.run_forever)
+        ws_thread.daemon = True
+        ws_thread.start()
+
+        # Wait for completion or error
+        while ws_thread.is_alive():
+            if error_occurred.wait(timeout=0.1):
+                ws.close()
+                break
+            if session_complete.wait(timeout=0.1):
+                break
+
+        ws_thread.join(timeout=5.0)
+
+        if error_occurred.is_set():
+            raise RuntimeError(f"AssemblyAI transcription failed: {error_message}")
+
+        # Combine all transcript parts
+        full_transcript = " ".join(transcript_parts).strip()
+        return full_transcript
+
+    def audio_to_chunks(self, audio_data, sample_rate):
+        """Convert audio data to chunks suitable for streaming."""
+        # Ensure audio is tensor
+        if not isinstance(audio_data, torch.Tensor):
+            audio_data = torch.tensor(audio_data)
+            
+        # Add batch dimension if needed
+        if audio_data.dim() == 1:
+            audio_data = audio_data.unsqueeze(0)
+
+        # Resample to target sample rate
+        if sample_rate != self.sample_rate:
+            audio_data = torchaudio.functional.resample(
+                audio_data, sample_rate, self.sample_rate
+            )
+
+        # Convert to mono if needed
+        if audio_data.shape[0] > 1:
+            audio_data = torch.mean(audio_data, dim=0, keepdim=True)
+
+        # Split into chunks
+        chunk_size = int(self.chunksize_ms * self.sample_rate / 1000)
+        audio_chunks = torch.split(audio_data, chunk_size, dim=1)
+
+        # Convert chunks to bytes
+        chunk_bytes = []
+        for chunk in audio_chunks:
+            # Convert to int16 and then to bytes
+            chunk_int16 = (chunk * 32768.0).clamp(-32768, 32767).to(torch.int16)
+            chunk_bytes.append(chunk_int16.numpy().tobytes())
+
+        return chunk_bytes
+
+    def __call__(self, sample, keywords=None):
+        """Process a transcription sample."""
+        audio_chunks = self.audio_to_chunks(sample.waveform, sample.sample_rate)
+        transcript = self.run(audio_chunks, keywords)
+        return transcript
+
+
+class AssemblyAITranscriptionPipelineConfig(TranscriptionConfig):
+    sample_rate: int = 16000
+    channels: int = 1
+    sample_width: int = 2
+    chunksize_ms: float = 50
+    endpoint_url: str = "wss://streaming.assemblyai.com/v3/ws"
+
+
+@register_pipeline
+class AssemblyAITranscriptionPipeline(Pipeline):
+    _config_class = AssemblyAITranscriptionPipelineConfig
+    pipeline_type = PipelineType.TRANSCRIPTION
+
+    def build_pipeline(self) -> Callable[[TranscriptionSample], str]:
+        assemblyai_api = AssemblyAIApi(self.config)
+
+        def transcribe(sample: TranscriptionSample) -> str:
+            return assemblyai_api(sample, keywords=self.current_keywords)
+
+        return transcribe
+
+    def parse_input(self, input_sample: TranscriptionSample) -> TranscriptionSample:
+        """Override to extract keywords from sample before processing."""
+        self.current_keywords = None
+        if self.config.use_keywords:
+            keywords = input_sample.extra_info.get('dictionary', [])
+            if keywords:
+                self.current_keywords = keywords
+
+        return input_sample
+
+    def parse_output(self, output: str) -> TranscriptionOutput:
+        # Split transcript into words
+        words = output.split() if output else []
+        transcript = Transcript.from_words_info(words=words)
+        return TranscriptionOutput(prediction=transcript)

--- a/src/openbench/pipeline/transcription/transcription_assemblyai.py
+++ b/src/openbench/pipeline/transcription/transcription_assemblyai.py
@@ -1,15 +1,11 @@
-import json
 import os
-import threading
 import time
 from pathlib import Path
 from typing import Callable
-from urllib.parse import urlencode
 
-import torch
-import torchaudio
-import websocket
+import requests
 from argmaxtools.utils import get_logger
+from pydantic import Field
 
 from ...dataset import TranscriptionSample
 from ...pipeline import Pipeline, register_pipeline
@@ -27,176 +23,64 @@ class AssemblyAIApi:
         self.api_key = os.getenv("ASSEMBLYAI_API_KEY")
         assert self.api_key is not None, "Please set ASSEMBLYAI_API_KEY in environment"
         
-        self.sample_rate = cfg.sample_rate
-        self.channels = cfg.channels
-        self.sample_width = cfg.sample_width
-        self.chunksize_ms = cfg.chunksize_ms
-        self.api_endpoint_base_url = cfg.endpoint_url
+        self.base_url = "https://api.assemblyai.com"
+        self.headers = {"authorization": self.api_key}
+        self.model_version = cfg.model_version
 
-    def get_api_endpoint(self, keywords=None):
-        """Build API endpoint with optional keywords."""
-        CONNECTION_PARAMS = {
-            "sample_rate": self.sample_rate,
-            "format_turns": True,  # Request formatted final transcripts
+    def transcribe(self, audio_path: Path, keywords=None):
+        """Transcribe audio file using AssemblyAI REST API."""
+        
+        # First, upload the audio file
+        with open(audio_path, "rb") as f:
+            upload_response = requests.post(
+                f"{self.base_url}/v2/upload",
+                headers=self.headers,
+                data=f
+            )
+            
+        if upload_response.status_code != 200:
+            raise RuntimeError(f"Upload failed: {upload_response.status_code}, {upload_response.text}")
+            
+        upload_url = upload_response.json()["upload_url"]
+        
+        # Prepare transcription request
+        data = {
+            "audio_url": upload_url,
+            "speech_model": self.model_version
         }
-
+        
         # Add keywords if provided
         if keywords:
-            CONNECTION_PARAMS["keyterms_prompt"] = json.dumps(keywords)
-
-        return f"{self.api_endpoint_base_url}?{urlencode(CONNECTION_PARAMS)}"
-
-    def run(self, audio_chunks, keywords=None):
-        """Run transcription on audio chunks."""
-        transcript_parts = []
-        session_complete = threading.Event()
-        error_occurred = threading.Event()
-        error_message = None
+            data["keyterms_prompt"] = keywords
+            logger.debug(f"Using keywords: {keywords}")
         
-        # Get API endpoint with keywords
-        api_endpoint = self.get_api_endpoint(keywords)
+        # Submit transcription request
+        url = f"{self.base_url}/v2/transcript"
+        response = requests.post(url, json=data, headers=self.headers)
+        
+        if response.status_code != 200:
+            raise RuntimeError(f"Transcription request failed: {response.status_code}, {response.text}")
+        
+        transcript_id = response.json()['id']
+        polling_endpoint = f"{self.base_url}/v2/transcript/{transcript_id}"
 
-        def on_open(ws):
-            def stream_audio(ws):
-                try:
-                    for chunk in audio_chunks:
-                        if error_occurred.is_set():
-                            break
-                        ws.send(chunk, opcode=websocket.ABNF.OPCODE_BINARY)
-                        time.sleep(self.chunksize_ms / 1000)
-                    
-                    # Send termination message
-                    terminate_message = json.dumps({"type": "Terminate"})
-                    ws.send(terminate_message, opcode=websocket.ABNF.OPCODE_TEXT)
-                except Exception as e:
-                    logger.error(f"Error streaming audio: {e}")
-                    nonlocal error_message
-                    error_message = str(e)
-                    error_occurred.set()
-
-            threading.Thread(target=stream_audio, args=(ws,)).start()
-
-        def on_message(ws, message):
-            nonlocal error_message
-            try:
-                data = json.loads(message)
-                msg_type = data.get("type")
-                
-                if msg_type == "Begin":
-                    session_id = data.get('id')
-                    logger.debug(f"Session began: ID={session_id}")
-                    
-                elif msg_type == "Turn":
-                    transcript = data.get('transcript', '')
-                    formatted = data.get('turn_is_formatted', False)
-                    
-                    if formatted and transcript.strip():
-                        transcript_parts.append(transcript.strip())
-                        logger.debug(f"Received transcript: {transcript}")
-                        
-                elif msg_type == "Termination":
-                    audio_duration = data.get('audio_duration_seconds', 0)
-                    session_duration = data.get('session_duration_seconds', 0)
-                    logger.debug(f"Session terminated: Audio={audio_duration}s, Session={session_duration}s")
-                    session_complete.set()
-                    
-            except json.JSONDecodeError as e:
-                logger.error(f"Error decoding message: {e}")
-                error_message = f"JSON decode error: {e}"
-                error_occurred.set()
-            except Exception as e:
-                logger.error(f"Error handling message: {e}")
-                error_message = f"Message handling error: {e}"
-                error_occurred.set()
-
-        def on_error(ws, error):
-            nonlocal error_message
-            logger.error(f"WebSocket error: {error}")
-            error_message = f"WebSocket error: {error}"
-            error_occurred.set()
-
-        def on_close(ws, close_status_code, close_msg):
-            logger.debug(f"WebSocket closed: Status={close_status_code}, Msg={close_msg}")
-            session_complete.set()
-
-        # Create and run WebSocket connection
-        ws = websocket.WebSocketApp(
-            api_endpoint,
-            header={"Authorization": self.api_key},
-            on_open=on_open,
-            on_message=on_message,
-            on_error=on_error,
-            on_close=on_close,
-        )
-
-        # Run WebSocket in a separate thread
-        ws_thread = threading.Thread(target=ws.run_forever)
-        ws_thread.daemon = True
-        ws_thread.start()
-
-        # Wait for completion or error
-        while ws_thread.is_alive():
-            if error_occurred.wait(timeout=0.1):
-                ws.close()
-                break
-            if session_complete.wait(timeout=0.1):
-                break
-
-        ws_thread.join(timeout=5.0)
-
-        if error_occurred.is_set():
-            raise RuntimeError(f"AssemblyAI transcription failed: {error_message}")
-
-        # Combine all transcript parts
-        full_transcript = " ".join(transcript_parts).strip()
-        return full_transcript
-
-    def audio_to_chunks(self, audio_data, sample_rate):
-        """Convert audio data to chunks suitable for streaming."""
-        # Ensure audio is tensor
-        if not isinstance(audio_data, torch.Tensor):
-            audio_data = torch.tensor(audio_data)
+        while True:
+            transcription_result = requests.get(polling_endpoint, headers=self.headers).json()
             
-        # Add batch dimension if needed
-        if audio_data.dim() == 1:
-            audio_data = audio_data.unsqueeze(0)
-
-        # Resample to target sample rate
-        if sample_rate != self.sample_rate:
-            audio_data = torchaudio.functional.resample(
-                audio_data, sample_rate, self.sample_rate
-            )
-
-        # Convert to mono if needed
-        if audio_data.shape[0] > 1:
-            audio_data = torch.mean(audio_data, dim=0, keepdim=True)
-
-        # Split into chunks
-        chunk_size = int(self.chunksize_ms * self.sample_rate / 1000)
-        audio_chunks = torch.split(audio_data, chunk_size, dim=1)
-
-        # Convert chunks to bytes
-        chunk_bytes = []
-        for chunk in audio_chunks:
-            # Convert to int16 and then to bytes
-            chunk_int16 = (chunk * 32768.0).clamp(-32768, 32767).to(torch.int16)
-            chunk_bytes.append(chunk_int16.numpy().tobytes())
-
-        return chunk_bytes
-
-    def __call__(self, sample, keywords=None):
-        """Process a transcription sample."""
-        audio_chunks = self.audio_to_chunks(sample.waveform, sample.sample_rate)
-        transcript = self.run(audio_chunks, keywords)
-        return transcript
+            if transcription_result['status'] == 'completed':
+                return transcription_result['text']
+            elif transcription_result['status'] == 'error':
+                raise RuntimeError(f"Transcription failed: {transcription_result['error']}")
+            else:
+                logger.debug(f"Transcription status: {transcription_result['status']}, waiting...")
+                time.sleep(3)
 
 
 class AssemblyAITranscriptionPipelineConfig(TranscriptionConfig):
-    sample_rate: int = 16000
-    channels: int = 1
-    sample_width: int = 2
-    chunksize_ms: float = 50
-    endpoint_url: str = "wss://streaming.assemblyai.com/v3/ws"
+    model_version: str = Field(
+        default="universal",
+        description="The version of the AssemblyAI speech model to use",
+    )
 
 
 @register_pipeline
@@ -204,15 +88,20 @@ class AssemblyAITranscriptionPipeline(Pipeline):
     _config_class = AssemblyAITranscriptionPipelineConfig
     pipeline_type = PipelineType.TRANSCRIPTION
 
-    def build_pipeline(self) -> Callable[[TranscriptionSample], str]:
+    def build_pipeline(self) -> Callable[[Path], str]:
         assemblyai_api = AssemblyAIApi(self.config)
 
-        def transcribe(sample: TranscriptionSample) -> str:
-            return assemblyai_api(sample, keywords=self.current_keywords)
+        def transcribe(audio_path: Path) -> str:
+            response = assemblyai_api.transcribe(
+                audio_path, keywords=self.current_keywords
+            )
+            # Remove temporary audio path
+            audio_path.unlink(missing_ok=True)
+            return response
 
         return transcribe
 
-    def parse_input(self, input_sample: TranscriptionSample) -> TranscriptionSample:
+    def parse_input(self, input_sample: TranscriptionSample) -> Path:
         """Override to extract keywords from sample before processing."""
         self.current_keywords = None
         if self.config.use_keywords:
@@ -220,7 +109,7 @@ class AssemblyAITranscriptionPipeline(Pipeline):
             if keywords:
                 self.current_keywords = keywords
 
-        return input_sample
+        return input_sample.save_audio(TEMP_AUDIO_DIR)
 
     def parse_output(self, output: str) -> TranscriptionOutput:
         # Split transcript into words

--- a/src/openbench/pipeline/transcription/transcription_nemo.py
+++ b/src/openbench/pipeline/transcription/transcription_nemo.py
@@ -22,14 +22,14 @@ from nemo.collections.asr.models import (
     EncDecHybridRNNTCTCModel,
 )
 from nemo.collections.asr.parts import context_biasing
-from nemo.utils import logging
-
+from argmaxtools.utils import get_logger
 
 from ...pipeline import Pipeline, register_pipeline
 from ...pipeline_prediction import Transcript
 from ...types import PipelineType
 from .common import TranscriptionConfig, TranscriptionOutput
 
+logger = get_logger(__name__)
 
 TEMP_AUDIO_DIR = Path("temp_audio_dir")
 
@@ -85,7 +85,7 @@ class NeMoTranscriptionPipeline(Pipeline):
                 map_location=torch.device(self.config.device),
             )
         else:
-            logging.warning(
+            logger.warning(
                 "nemo_model_file does not end with .nemo, "
                 "trying to load pretrained model."
             )


### PR DESCRIPTION
This PR introduces:

- `AssemblyAI` Streaming Benchmark
- `AssemblyAI` Transcription Benchmark with `Keyword Boosting` Support

**Testing** 

**Example CLI command (Streaming Transcription):**
```
openbench-cli evaluate \
  --pipeline assemblyai-streaming \
  --dataset timit-debug \
  --metrics streaming_latency \
  -m confirmed_streaming_latency \
  -m wer
```
**Example Result (Streaming Transcription):**

<img width="627" height="125" alt="Screenshot 2025-09-25 at 7 46 20 PM" src="https://github.com/user-attachments/assets/d773fd19-40b9-4485-b6af-c7eb212e3129" />


**Example CLI command (Transcription without Keyword Boosting):**
```
openbench-cli evaluate \
  --pipeline assemblyai-transcription \
  --dataset earnings22-keywords-debug \
  --metrics keyword_fscore \
  -m keyword_recall \
  -m keyword_precision \
  -m wer
```
**Example Result (Streaming Transcription):**

<img width="661" height="142" alt="Screenshot 2025-09-25 at 6 56 20 PM" src="https://github.com/user-attachments/assets/c7ceabcd-2933-418b-9d49-b48239ecb58f" />

**Example CLI command (Transcription with Keyword Boosting):**
```
openbench-cli evaluate \
  --pipeline assemblyai-transcription \
  --dataset earnings22-keywords-debug \
  --metrics keyword_fscore \
  -m keyword_recall \
  -m keyword_precision \
  -m wer \
  --use-keywords
```
**Example Result (Transcription with Keyword Boosting):**

<img width="650" height="139" alt="Screenshot 2025-09-25 at 6 55 12 PM" src="https://github.com/user-attachments/assets/e5972664-77a8-4ad0-a008-83a372eaed59" />





