### PR TITLE
New dataset CLI command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ inference_outputs/
 
 # Miscellaneous
 miscellaneous/
+
+# Default openbench-cli output directory
+downloaded_datasets/

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ install-pre-commit:
 format:
 	@pre-commit run --all-files
 	@echo "Just to be sure, we're running ruff again..."
-	@uvx ruff check --fix .
-	@uvx ruff format .
+	@uvx ruff check --fix src/
+	@uvx ruff format src/
 
 display-config:
 	@uv run python evaluation.py -h

--- a/src/openbench/cli/commands/__init__.py
+++ b/src/openbench/cli/commands/__init__.py
@@ -3,9 +3,10 @@
 
 """CLI commands module."""
 
+from . import dataset
 from .evaluate import evaluate
 from .inference import inference
 from .summary import summary
 
 
-__all__ = ["evaluate", "inference", "summary"]
+__all__ = ["dataset", "evaluate", "inference", "summary"]

--- a/src/openbench/cli/commands/dataset/__init__.py
+++ b/src/openbench/cli/commands/dataset/__init__.py
@@ -1,0 +1,30 @@
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
+
+"""Dataset command for openbench-cli."""
+
+import typer
+from rich.console import Console
+
+from .download import download
+
+
+console = Console()
+
+app = typer.Typer(
+    name="dataset",
+    help="Dataset management commands for OpenBench",
+    add_completion=False,
+)
+
+# Add subcommands
+app.command()(download)
+
+
+def main() -> None:
+    """Main entry point for the dataset command."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openbench/cli/commands/dataset/download.py
+++ b/src/openbench/cli/commands/dataset/download.py
@@ -1,0 +1,234 @@
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
+
+"""Download command for dataset CLI."""
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from openbench.dataset import DatasetRegistry
+from openbench.types import PipelineType
+
+
+console = Console()
+
+
+def download(
+    dataset_name: str | None = typer.Option(
+        None, "--dataset-name", "-d", help="Name of the dataset alias to download (must be a registered dataset alias)"
+    ),
+    pipeline_type: PipelineType | None = typer.Option(
+        None,
+        "--pipeline-type",
+        "-p",
+        help="Pipeline type for the dataset. If the passed dataset alias has multiple supported pipeline types, this option is required.",
+    ),
+    sample_id: int | None = typer.Option(None, "--sample-id", "-s", min=0, help="Specific sample ID to download"),
+    audio_name: str | None = typer.Option(None, "--audio-name", "-a", help="Specific audio name to download"),
+    output_dir: Path | None = typer.Option(
+        None,
+        "--output-dir",
+        "-o",
+        help="Output directory for downloaded files. If not provided download will occur in `downloaded_datasets/<dataset_name>`",
+    ),
+) -> None:
+    """Download a dataset or specific samples from a dataset.
+
+    This command can download:
+
+    - The entire dataset (default behavior)
+
+    - A specific sample by sample ID
+
+    - A specific sample by audio name
+
+    The dataset_name must be one of the registered dataset aliases.
+
+    Examples:
+
+        # Download entire dataset
+
+
+        openbench-cli dataset download --dataset-name my-dataset
+
+
+        # Download with specific pipeline type
+
+
+        openbench-cli dataset download --dataset-name my-dataset --pipeline-type transcription
+
+
+        # Download specific sample by ID
+
+
+        openbench-cli dataset download --dataset-name my-dataset --sample-id 123
+
+
+        # Download specific sample by audio name
+
+
+        openbench-cli dataset download --dataset-name my-dataset --audio-name sample_001.wav
+
+
+        # Download to specific directory
+
+
+        openbench-cli dataset download --dataset-name my-dataset --output-dir ./my_data
+
+    """
+    try:
+        # Validate that dataset_name is provided
+        if dataset_name is None:
+            console.print("[red]Error: --dataset-name is required[/red]")
+            raise typer.Exit(1)
+
+        # Validate that only one of sample_id or audio_name is provided
+        if sample_id and audio_name:
+            console.print("[red]Error: Cannot specify both --sample-id and --audio-name[/red]")
+            raise typer.Exit(1)
+
+        # Validate that dataset_name is a registered alias
+        available_aliases = DatasetRegistry.list_aliases()
+        if dataset_name not in available_aliases:
+            console.print(f"[red]Error: Dataset alias '{dataset_name}' not found.[/red]")
+            console.print(f"[yellow]Available dataset aliases: {', '.join(available_aliases)}[/yellow]")
+            raise typer.Exit(1)
+
+        # Get the dataset
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Loading dataset...", total=None)
+
+            try:
+                dataset = DatasetRegistry.get_dataset_from_alias(dataset_name, pipeline_type)
+                progress.update(task, description="Dataset loaded successfully")
+            except Exception as e:
+                console.print(f"[red]Error loading dataset: {e}[/red]")
+                raise typer.Exit(1)
+
+        # Set output directory
+        if output_dir:
+            output_path = Path(output_dir)
+        else:
+            output_path = Path("downloaded_datasets") / dataset_name
+
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        # Download based on the specified options
+        if sample_id:
+            _download_sample_by_id(dataset, sample_id, output_path)
+        elif audio_name:
+            _download_sample_by_audio_name(dataset, audio_name, output_path)
+        else:
+            _download_full_dataset(dataset, output_path)
+
+        console.print(f"[green]Download completed successfully to: {output_path}[/green]")
+
+    except Exception as e:
+        console.print(f"[red]Error during download: {e}[/red]")
+        raise typer.Exit(1)
+
+
+def _download_full_dataset(dataset, output_path: Path) -> None:
+    """Download the entire dataset."""
+    console.print(f"[blue]Downloading full dataset to {output_path}[/blue]")
+
+    # Create subdirectories for different data types
+    audio_dir = output_path / "audio"
+    metadata_dir = output_path / "metadata"
+    reference_dir = output_path / "reference"
+    audio_dir.mkdir(exist_ok=True)
+    metadata_dir.mkdir(exist_ok=True)
+    reference_dir.mkdir(exist_ok=True)
+
+    # Download all samples
+    for i in range(len(dataset)):
+        sample = dataset[i]
+        _save_sample(sample, audio_dir, metadata_dir, reference_dir, i)
+
+
+def _download_sample_by_id(dataset, sample_id: int, output_path: Path) -> None:
+    """Download a specific sample by sample ID."""
+    if sample_id >= len(dataset):
+        console.print(f"[red]Error: Sample ID {sample_id} is out of range (0-{len(dataset) - 1})[/red]")
+        raise typer.Exit(1)
+
+    console.print(f"[blue]Downloading sample {sample_id} to {output_path}[/blue]")
+
+    # Create subdirectories
+    audio_dir = output_path / "audio"
+    metadata_dir = output_path / "metadata"
+    reference_dir = output_path / "reference"
+    audio_dir.mkdir(exist_ok=True)
+    metadata_dir.mkdir(exist_ok=True)
+    reference_dir.mkdir(exist_ok=True)
+
+    sample = dataset[sample_id]
+    _save_sample(sample, audio_dir, metadata_dir, reference_dir, sample_id)
+
+
+def _download_sample_by_audio_name(dataset, audio_name: str, output_path: Path) -> None:
+    """Download a specific sample by audio name."""
+    console.print(f"[blue]Searching for audio file '{audio_name}'...[/blue]")
+
+    found_idx = None
+    for i in range(len(dataset)):
+        sample = dataset[i]
+        if sample.audio_name == audio_name or sample.audio_name == Path(audio_name).stem:
+            found_idx = i
+            break
+
+    if found_idx is None:
+        console.print(f"[red]Error: Audio file '{audio_name}' not found in dataset[/red]")
+        raise typer.Exit(1)
+
+    console.print(f"[blue]Found audio file at index {found_idx}, downloading to {output_path}[/blue]")
+
+    # Create subdirectories
+    audio_dir = output_path / "audio"
+    metadata_dir = output_path / "metadata"
+    reference_dir = output_path / "reference"
+    audio_dir.mkdir(exist_ok=True)
+    metadata_dir.mkdir(exist_ok=True)
+    reference_dir.mkdir(exist_ok=True)
+
+    sample = dataset[found_idx]
+    _save_sample(sample, audio_dir, metadata_dir, reference_dir, found_idx)
+
+
+def _save_sample(sample, audio_dir: Path, metadata_dir: Path, reference_dir: Path, idx: int) -> None:
+    """Save a sample to disk."""
+    import json
+
+    import soundfile as sf
+
+    # Save audio file
+    audio_filename = f"{sample.audio_name}.wav"
+    audio_path = audio_dir / audio_filename
+    sf.write(audio_path, sample.waveform, sample.sample_rate)
+
+    # Save reference file
+    sample.reference.to_annotation_file(str(reference_dir), sample.audio_name)
+
+    # Save metadata
+    metadata = {
+        "sample_index": idx,
+        "audio_name": sample.audio_name,
+        "sample_rate": sample.sample_rate,
+        "duration": len(sample.waveform) / sample.sample_rate,
+        "reference": sample.reference.model_dump()
+        if hasattr(sample.reference, "model_dump")
+        else str(sample.reference),
+        "extra_info": sample.extra_info,
+    }
+
+    metadata_filename = f"{sample.audio_name}_metadata.json"
+    metadata_path = metadata_dir / metadata_filename
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2, default=str)

--- a/src/openbench/cli/main.py
+++ b/src/openbench/cli/main.py
@@ -5,7 +5,7 @@
 
 import typer
 
-from openbench.cli.commands import evaluate, inference, summary
+from openbench.cli.commands import dataset, evaluate, inference, summary
 
 
 app = typer.Typer(
@@ -15,6 +15,7 @@ app = typer.Typer(
 )
 
 # Add commands to the app
+app.add_typer(dataset.app, name="dataset")
 app.command()(evaluate)
 app.command()(inference)
 app.command()(summary)

--- a/src/openbench/types.py
+++ b/src/openbench/types.py
@@ -3,15 +3,15 @@
 
 """Shared types used across the openbench package."""
 
-from enum import Enum, auto
+from enum import Enum
 from typing import Protocol, runtime_checkable
 
 
 class PipelineType(Enum):
-    DIARIZATION = auto()
-    TRANSCRIPTION = auto()
-    ORCHESTRATION = auto()
-    STREAMING_TRANSCRIPTION = auto()
+    DIARIZATION = "diarization"
+    TRANSCRIPTION = "transcription"
+    ORCHESTRATION = "orchestration"
+    STREAMING_TRANSCRIPTION = "streaming_transcription"
 
 
 # All prediction classes that we output should conform to this


### PR DESCRIPTION
# What does this PR do?

This PR introduces the `openbench-cli dataset` command, which has its own `download` subcommand and could potentially include other commands in the future. The usefulness of this command comes from the fact that currently `openbench` only works with Hugging Face `datasets` format (i.e., `.parquet` files) + a very strict schema. It is often the case that after getting the results from `openbench-cli evaluate`, one wants to take a closer look at the performance on a particular file to better understand what happened there. Still, since the HF format embeds the audio in the `.parquet`, it is cumbersome to retrieve the audio; now this is unblocked by `openbench-cli dataset download`.

Moreover, also introduced `column_mapping` and `column_transforms` to `DatasetConfig` to give more flexibility for the datasets and potentially unlock datasets that already exist in the hub to be compatible with `openbench`.

## OpenBench Dataset Download Command Guide

## Command Syntax

```bash
openbench-cli dataset download [OPTIONS]
```

## Available Options

| Option | Short | Description | Required |
|--------|-------|-------------|----------|
| `--dataset-name` | `-d` | Name of the dataset alias to download | ✅ |
| `--pipeline-type` | `-p` | Pipeline type (required for multi-type datasets) | ⚠️ |
| `--sample-id` | `-s` | Download specific sample by ID (0-based index) | ❌ |
| `--audio-name` | `-a` | Download specific sample by audio filename | ❌ |
| `--output-dir` | `-o` | Custom output directory | ❌ |

## Output Format

If you don't specify an `--output-dir` the default dir will be `downloaded_datasets/<dataset-name>`

```bash
downloaded_datasets/
└── <dataset-name>
    ├── audio
    │   └── <audio-name>.flac
    ├── metadata
    │   └── <audio_name>_metadata.json
    └── reference
        └── <audio_name>.rttm
```

## Usage Examples

### 1. Download Entire Dataset
```bash
openbench-cli dataset download --dataset-name voxconverse
```
**What happens:**
- Downloads all samples from the VoxConverse dataset
- Creates directory: `downloaded_datasets/voxconverse/`
- Organizes files into subdirectories (see structure above)

### 2. Download with Pipeline Type
```bash
openbench-cli dataset download --dataset-name earnings21 --pipeline-type transcription
```
**What happens:**
- Downloads Earnings21 dataset configured for transcription
- Required because Earnings21 supports multiple pipeline types (diarization, transcription, orchestration)

### 3. Download Specific Sample by ID
```bash
openbench-cli dataset download --dataset-name voxconverse --sample-id 5
```
**What happens:**
- Downloads only sample at index 5 (6th sample, 0-based indexing)
- Creates same directory structure but with only one sample

### 4. Download Specific Sample by Audio Name
```bash
openbench-cli dataset download --dataset-name voxconverse --audio-name sample_001
```
**What happens:**
- Searches for audio file matching "sample_001.flac" or "sample_001"
- Downloads the matching sample when found

### 5. Custom Output Directory
```bash
openbench-cli dataset download --dataset-name voxconverse --output-dir ./my_data/voxconverse_test
```
**What happens:**
- Downloads to `./my_data/voxconverse_test/` instead of default location
- Creates directory if it doesn't exist
