### PR TITLE
By default let HF download handle cache path for WhisperKitPro Engine

### DIFF
--- a/src/openbench/pipeline/orchestration/orchestration_whisperkitpro.py
+++ b/src/openbench/pipeline/orchestration/orchestration_whisperkitpro.py
@@ -21,22 +21,46 @@ TEMP_AUDIO_DIR = Path("./temp_audio")
 
 
 class WhisperKitProOrchestrationConfig(OrchestrationConfig):
+    """Configuration for WhisperKitPro orchestration pipeline.
+
+    Supports two modes:
+    1. Legacy: model_version, model_prefix, model_repo_name
+    2. New: repo_id, model_variant (downloads and manages models)
+    """
+
     cli_path: str = Field(
         ...,
         description="The path to the WhisperKitPro CLI",
     )
-    model_version: str = Field(
-        ...,
-        description="The version of the WhisperKitPro model to use",
+
+    # Legacy fields (optional)
+    model_version: str | None = Field(
+        None,
+        description="(Legacy) The version of the WhisperKitPro model to use",
     )
-    model_prefix: str = Field(
-        "openai",
-        description="The prefix of the model to use.",
+    model_prefix: str | None = Field(
+        None,
+        description="(Legacy) The prefix of the model to use.",
     )
     model_repo_name: str | None = Field(
-        "argmaxinc/whisperkit-pro",
-        description="The name of the Hugging Face model repo to use. Default is `argmaxinc/whisperkit-pro` which has Whisper checkpoints models.",
+        None,
+        description="(Legacy) The name of the Hugging Face model repo to use.",
     )
+
+    # New fields for model download and management
+    repo_id: str | None = Field(
+        None,
+        description="HuggingFace repo ID",
+    )
+    model_variant: str | None = Field(
+        None,
+        description="Model variant folder name",
+    )
+    models_cache_dir: str | None = Field(
+        None,
+        description="Directory to cache downloaded models",
+    )
+
     audio_encoder_compute_units: ComputeUnit = Field(
         ComputeUnit.CPU_AND_NE,
         description="The compute units to use for the audio encoder. Default is CPU_AND_NE.",
@@ -73,6 +97,9 @@ class WhisperKitProOrchestrationPipeline(Pipeline):
             model_version=self.config.model_version,
             model_prefix=self.config.model_prefix,
             model_repo_name=self.config.model_repo_name,
+            repo_id=self.config.repo_id,
+            model_variant=self.config.model_variant,
+            models_cache_dir=self.config.models_cache_dir,
             audio_encoder_compute_units=self.config.audio_encoder_compute_units,
             text_decoder_compute_units=self.config.text_decoder_compute_units,
             report_path="whisperkitpro_orchestration_reports",

--- a/src/openbench/pipeline/orchestration/orchestration_whisperkitpro.py
+++ b/src/openbench/pipeline/orchestration/orchestration_whisperkitpro.py
@@ -56,9 +56,9 @@ class WhisperKitProOrchestrationConfig(OrchestrationConfig):
         None,
         description="Model variant folder name",
     )
-    models_cache_dir: str | None = Field(
+    model_dir: str | None = Field(
         None,
-        description="Directory to cache downloaded models",
+        description="Local path to model directory. If provided, models are loaded from this path directly instead of downloading.",
     )
 
     audio_encoder_compute_units: ComputeUnit = Field(
@@ -99,7 +99,7 @@ class WhisperKitProOrchestrationPipeline(Pipeline):
             model_repo_name=self.config.model_repo_name,
             repo_id=self.config.repo_id,
             model_variant=self.config.model_variant,
-            models_cache_dir=self.config.models_cache_dir,
+            model_dir=self.config.model_dir,
             audio_encoder_compute_units=self.config.audio_encoder_compute_units,
             text_decoder_compute_units=self.config.text_decoder_compute_units,
             report_path="whisperkitpro_orchestration_reports",

--- a/src/openbench/pipeline/pipeline_aliases.py
+++ b/src/openbench/pipeline/pipeline_aliases.py
@@ -175,9 +175,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-tiny",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "tiny",
-            "model_prefix": "openai",
-            "model_repo_name": "argmaxinc/whisperkit-pro",
+            "repo_id": "argmaxinc/whisperkit-pro",
+            "model_variant": "openai_whisper-tiny",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -190,9 +189,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-large-v3",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "large-v3",
-            "model_prefix": "openai",
-            "model_repo_name": "argmaxinc/whisperkit-pro",
+            "repo_id": "argmaxinc/whisperkit-pro",
+            "model_variant": "openai_whisper-large-v3",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -205,9 +203,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-large-v3-turbo",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "large-v3-v20240930",
-            "model_prefix": "openai",
-            "model_repo_name": "argmaxinc/whisperkit-pro",
+            "repo_id": "argmaxinc/whisperkit-pro",
+            "model_variant": "openai_whisper-large-v3-v20240930",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -220,9 +217,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-large-v3-turbo-compressed",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "large-v3-v20240930_626MB",
-            "model_prefix": "openai",
-            "model_repo_name": "argmaxinc/whisperkit-pro",
+            "repo_id": "argmaxinc/whisperkit-pro",
+            "model_variant": "openai_whisper-large-v3-v20240930_626MB",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -235,9 +231,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-parakeet-v2",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "parakeet-v2",
-            "model_prefix": "nvidia",
-            "model_repo_name": "argmaxinc/parakeetkit-pro",
+            "repo_id": "argmaxinc/parakeetkit-pro",
+            "model_variant": "nvidia_parakeet-v2",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -250,9 +245,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-parakeet-v2-compressed",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "parakeet-v2_476MB",
-            "model_prefix": "nvidia",
-            "model_repo_name": "argmaxinc/parakeetkit-pro",
+            "repo_id": "argmaxinc/parakeetkit-pro",
+            "model_variant": "nvidia_parakeet-v2_476MB",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -265,9 +259,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-parakeet-v3",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "parakeet-v3",
-            "model_prefix": "nvidia",
-            "model_repo_name": "argmaxinc/parakeetkit-pro",
+            "repo_id": "argmaxinc/parakeetkit-pro",
+            "model_variant": "nvidia_parakeet-v3",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -280,9 +273,8 @@ def register_pipeline_aliases() -> None:
         "whisperkitpro-orchestration-parakeet-v3-compressed",
         WhisperKitProOrchestrationPipeline,
         default_config={
-            "model_version": "parakeet-v3_494MB",
-            "model_prefix": "nvidia",
-            "model_repo_name": "argmaxinc/parakeetkit-pro",
+            "repo_id": "argmaxinc/parakeetkit-pro",
+            "model_variant": "nvidia_parakeet-v3_494MB",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
             "orchestration_strategy": "segment",
             "clusterer_version_string": "pyannote4",
@@ -377,9 +369,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/whisperkit-pro",
             "model_variant": "openai_whisper-tiny",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the tiny version of the model. Requires Swift and Xcode installed. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -390,9 +380,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/whisperkit-pro",
             "model_variant": "openai_whisper-large-v3",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the large-v3 version of the model. Requires Swift and Xcode installed. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -403,9 +391,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/whisperkit-pro",
             "model_variant": "openai_whisper-large-v3-v20240930",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the large-v3-v20240930 version of the model (which is the same as large-v3-turbo from OpenAI). Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -416,9 +402,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/whisperkit-pro",
             "model_variant": "openai_whisper-large-v3-v20240930_626MB",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the large-v3-v20240930 version of the model compressed to 626MB (which is the same as large-v3-turbo from OpenAI). Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -429,9 +413,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/parakeetkit-pro",
             "model_variant": "nvidia_parakeet-v2",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the parakeet-v2 version of the model. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -442,9 +424,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/parakeetkit-pro",
             "model_variant": "nvidia_parakeet-v2_476MB",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the parakeet-v2 version of the model compressed to 476MB. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -455,9 +435,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/parakeetkit-pro",
             "model_variant": "nvidia_parakeet-v3",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the parakeet-v3 version of the model. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )
@@ -468,9 +446,7 @@ def register_pipeline_aliases() -> None:
         default_config={
             "repo_id": "argmaxinc/parakeetkit-pro",
             "model_variant": "nvidia_parakeet-v3_494MB",
-            "models_cache_dir": "./models_cache",
             "cli_path": os.getenv("WHISPERKITPRO_CLI_PATH"),
-            "use_keywords": False,
         },
         description="WhisperKitPro transcription pipeline using the parakeet-v3 version of the model compressed to 494MB. Requires `WHISPERKITPRO_CLI_PATH` env var and depending on your permissions also `WHISPERKITPRO_API_KEY` env var.",
     )

--- a/src/openbench/pipeline/transcription/transcription_whisperkitpro.py
+++ b/src/openbench/pipeline/transcription/transcription_whisperkitpro.py
@@ -57,7 +57,7 @@ class WhisperKitProTranscriptionConfig(TranscriptionConfig):
         None,
         description="Model variant folder name",
     )
-    models_cache_dir: str | None = Field(
+    model_dir: str | None = Field(
         None,
         description="Directory to cache downloaded models",
     )
@@ -92,7 +92,7 @@ class WhisperKitProTranscriptionPipeline(Pipeline):
             model_repo_name=self.config.model_repo_name,
             repo_id=self.config.repo_id,
             model_variant=self.config.model_variant,
-            models_cache_dir=self.config.models_cache_dir,
+            model_dir=self.config.model_dir,
             audio_encoder_compute_units=(self.config.audio_encoder_compute_units),
             text_decoder_compute_units=(self.config.text_decoder_compute_units),
             report_path="whisperkitpro_transcription_reports",


### PR DESCRIPTION
# What does this PR do?

### Problem

Pipeline aliases generate a new download path on each CLI run, bypassing the cache and causing unnecessary model re-downloads.

### Solution

Delegate model caching to HuggingFace's built-in cache mechanism:
- **Downloading**: When using `repo_id` + `model_variant`, models are stored in HF's default cache path, ensuring cache hits across runs
- **Local models**: When `model_dir` is provided, models are loaded directly from that path (no download)

### Changes
- Extended model downloads to `WhisperKitProOrchestrationPipeline`
- Added `repo_id` and `model_variant` for HF-managed downloads
- Switched `models_cache_dir` logic to a simple `model_dir` to load models from a local path directly
- Updated `build_pipeline` in transcription and orchestration to pass new fields to `WhisperKitProConfig`