### PR TITLE
Add metric-keywords support for custom vocabulary

### DIFF
--- a/src/openbench/dataset/dataset_transcription.py
+++ b/src/openbench/dataset/dataset_transcription.py
@@ -13,6 +13,7 @@ class TranscriptionExtraInfo(TypedDict, total=False):
 
     language: str
     dictionary: list[str]
+    metric_keywords: list[str]
 
 
 class TranscriptionRow(TypedDict):
@@ -24,6 +25,7 @@ class TranscriptionRow(TypedDict):
     word_timestamps_end: NotRequired[list[float]]
     language: NotRequired[str]
     dictionary: NotRequired[list[str]]
+    metric_keywords: NotRequired[list[str]]
 
 
 class TranscriptionSample(BaseSample[Transcript, TranscriptionExtraInfo]):
@@ -38,6 +40,11 @@ class TranscriptionSample(BaseSample[Transcript, TranscriptionExtraInfo]):
     def dictionary(self) -> list[str] | None:
         """Convenience property to access dictionary from extra_info."""
         return self.extra_info.get("dictionary")
+
+    @property
+    def metric_keywords(self) -> list[str] | None:
+        """Convenience property to access metric keywords from extra_info."""
+        return self.extra_info.get("metric_keywords")
 
 
 class TranscriptionDataset(BaseDataset[TranscriptionSample]):
@@ -60,4 +67,7 @@ class TranscriptionDataset(BaseDataset[TranscriptionSample]):
             extra_info["language"] = row["language"]
         if "dictionary" in row:
             extra_info["dictionary"] = row["dictionary"]
+        metric_keywords = row.get("metric-keywords") or row.get("metric_keywords")
+        if metric_keywords:
+            extra_info["metric_keywords"] = metric_keywords
         return reference, extra_info

--- a/src/openbench/runner/benchmark.py
+++ b/src/openbench/runner/benchmark.py
@@ -125,7 +125,11 @@ class BenchmarkRunner:
 
         for metric_name, metric in metrics_dict.items():
             reference = sample.reference
-            kwargs = sample.extra_info
+            kwargs = dict(sample.extra_info)
+
+            # Use metric_keywords for metric calculation if available, falling back to dictionary
+            if "metric_keywords" in kwargs:
+                kwargs["dictionary"] = kwargs.pop("metric_keywords")
 
             # The metric returns a dictionary that is also stored in the metric object as a state to compute the global result
             # We copy to avoid any side effects that may happen while interacting with dictionary for reporting
@@ -254,10 +258,15 @@ class BenchmarkRunner:
             # Update metric with all results
             for sample_result in per_sample_results:
                 sample = dataset[sample_result.sample_id]
-                # Get UEM from extra_info if available
                 kwargs = {}
-                if hasattr(sample, "extra_info") and "uem" in sample.extra_info:
-                    kwargs["uem"] = sample.extra_info["uem"]
+                if hasattr(sample, "extra_info"):
+                    if "uem" in sample.extra_info:
+                        kwargs["uem"] = sample.extra_info["uem"]
+                    # Use metric_keywords for metric calculation if available, falling back to dictionary
+                    if "metric_keywords" in sample.extra_info:
+                        kwargs["dictionary"] = sample.extra_info["metric_keywords"]
+                    elif "dictionary" in sample.extra_info:
+                        kwargs["dictionary"] = sample.extra_info["dictionary"]
 
                 metric(hypothesis=sample_result.prediction, reference=sample.reference, detailed=True, **kwargs)
 


### PR DESCRIPTION
This PR adds support for a `metric-keywords` column in datasets, enabling keyword-based metrics (F-score, precision, recall) to be computed against a separate set of keywords rather than the custom vocabulary passed to the WhisperKit CLI.
